### PR TITLE
Use -- to pass arguments through npm run commands

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npm run build:docs --pathprefix="nhsapp-frontend"
+      - run: npm run build:docs -- --pathprefix="nhsapp-frontend"
       - uses: actions/upload-pages-artifact@v3
         with:
           path: 'dist/docs'


### PR DESCRIPTION
Fixes missing basepath in deployed github pages