### PR TITLE
Remove use of the `url` filter

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -1,6 +1,6 @@
 <div class="app-example">
   <span class="app-example__new-window">
-    <a href="{{ href | url }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new window</a>
+    <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new window</a>
   </span>
   <iframe
     onload="this.style.height = this.contentWindow.document.documentElement.scrollHeight + 'px';"
@@ -8,7 +8,7 @@
     scrolling="auto"
     frameborder="0"
     height="{{ height }}"
-    src="{{ href | url }}"
+    src="{{ href }}"
     title="{{ title }}"
   ></iframe>
 </div>

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -5,7 +5,7 @@
 {% set sidebar %}
   {{ appSideNavigation({
     classes: 'nhsuk-u-padding-top-6',
-    currentPath: page.url | url,
+    currentPath: page.url,
     sections: [
       {
         heading: {


### PR DESCRIPTION
This is not needed with 11ty base plugin.

This fixes two issues:
1. "active" page state not working in sidebar navigation
2. iframe 404 on code examples