### PR TITLE
Sort components by title alphabetically in sidebar nav

### DIFF
--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -5,7 +5,7 @@
 {% set sidebar %}
   {{ appSideNavigation({
     currentPath: page.url,
-    items: collections.component
+    items: collections.component | sort(attribute="data.title")
   }) }}
 {% endset %}
 


### PR DESCRIPTION
The default collection sorting is by creation date of the file https://www.11ty.dev/docs/collections/#sorting.
This means that the order is not well defined, because it depends on a side effect of cloning the repo / moving branches etc.
We add a manual sort to make sure it's always alphabetical.
Fixes #78 