### PR TITLE
Remove pathprefix flag from eleventy build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npm run docs:build -- --pathprefix="nhsapp-frontend"
+      - run: npm run docs:build
       - uses: actions/upload-pages-artifact@v3
         with:
           path: 'dist/docs'


### PR DESCRIPTION
We have configured a custom domain to serve our docs and so we no longer need a path prefix