### PR TITLE
Read only card

### DIFF
--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -15,6 +15,10 @@ $card-border-hover-color: $color_nhsuk-grey-3;
 
   padding: 0;
 
+  &__title {
+    margin-bottom: 0;
+  }
+
   .nhsapp-icon {
     height: 24px;
     width: 24px;

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -16,6 +16,8 @@ $card-border-hover-color: $color_nhsuk-grey-3;
   padding: 0;
 
   &__title {
+    @include nhsuk-typography-responsive(22);
+    font-weight: bold;
     margin-bottom: 0;
   }
 
@@ -74,11 +76,6 @@ $card-border-hover-color: $color_nhsuk-grey-3;
       right: 0;
       top: 0;
     }
-  }
-
-  &__title {
-    @include nhsuk-typography-responsive(22);
-    font-weight: bold;
   }
 
   &__below {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -76,6 +76,11 @@ $card-border-hover-color: $color_nhsuk-grey-3;
     }
   }
 
+  &__title {
+    @include nhsuk-typography-responsive(22);
+    font-weight: bold;
+  }
+
   &__below {
     :last-child {
       margin-bottom: 0;

--- a/src/components/card/card-group.njk
+++ b/src/components/card/card-group.njk
@@ -14,6 +14,8 @@
       description: cardItem.description,
       badgeLarge: cardItem.badgeLarge,
       prefixIcon: cardItem.prefixIcon,
+      readOnly: cardItem.readOnly,
+      headingLevel: cardItem.headingLevel,
       isListItem: true
     }) }}
   {% endfor %}

--- a/src/components/card/card-group.njk
+++ b/src/components/card/card-group.njk
@@ -15,7 +15,6 @@
       badgeLarge: cardItem.badgeLarge,
       prefixIcon: cardItem.prefixIcon,
       readOnly: cardItem.readOnly,
-      headingLevel: cardItem.headingLevel,
       isListItem: true
     }) }}
   {% endfor %}

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -21,7 +21,7 @@
         </div>
       {%- endif -%}
       {%- if params.readOnly -%}
-        <h3 class="nhsapp-card__title">{{ params.title }}</h3>
+        <p class="nhsapp-card__title">{{ params.title }}</p>
       {%- else -%}
         <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
       {%- if params.linkAriaLabel %} aria-label="{{ params.linkAriaLabel }}" {% endif %}>
@@ -45,7 +45,7 @@
       }) }}
     {% endif %}
     {%- if not params.readOnly -%}
-      {{ icon('chevronRight') }}
+      {{ nhsappIcon('chevronRight') }}
     {%- endif -%}
   </div>
 {%- if params.isListItem -%}

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -20,10 +20,14 @@
           {{ params.aboveContent.html | safe }}
         </div>
       {%- endif -%}
-      <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
+      {%- if params.readOnly -%}
+        <h3 class="nhsapp-card__title">{{ params.title }}</h3>
+      {%- else -%}
+        <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
       {%- if params.linkAriaLabel %} aria-label="{{ params.linkAriaLabel }}" {% endif %}>
-        {{ params.title }}
-      </a>
+          {{ params.title }}
+        </a>
+      {%- endif -%}
       {% if params.description %}
         <div class="nhsapp-card__below">
           <p class="nhsuk-u-margin-top-1">{{ params.description }}</p>
@@ -40,7 +44,9 @@
         ariaHidden: params.badgeLarge.ariaHidden
       }) }}
     {% endif %}
-    {{ nhsappIcon('chevronRight') }}
+    {%- if not params.readOnly -%}
+      {{ icon('chevronRight') }}
+    {%- endif -%}
   </div>
 {%- if params.isListItem -%}
   </li>

--- a/src/styles/section-heading/section-heading.njk
+++ b/src/styles/section-heading/section-heading.njk
@@ -1,10 +1,11 @@
 {% set subheadingClass = 'nhsuk-u-margin-bottom-3' if params.subheadingText else '' %}
+{% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
 <div class="nhsapp-section-heading 
 {{ params.classes if params.classes }}">
-  <h2 class="nhsuk-heading-s {{ subheadingClass }}">
+  <h{{ headingLevel }} class="nhsuk-heading-s {{ subheadingClass }}">
     {{ params.headingText }}
-  </h2>
+  </h{{ headingLevel }}>
   {% if params.linkText and params.linkUrl %}
     <a 
       class="nhsuk-link nhsuk-link--no-visited-state nhsuk-u-nowrap"


### PR DESCRIPTION
![SUS Cards (non-interactive) (1)](https://github.com/user-attachments/assets/a619cf33-34a2-4c54-ba59-3e7c6edda618)

- add `readOnly` param to template
- replace `a` tag with heading
- hide chevron icon