### PR TITLE
Update card macro paths

### DIFF
--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -1,5 +1,5 @@
-{% from "badge/large/macro.njk" import nhsappBadgeLarge %}
-{% from "icon/macro.njk" import nhsappIcon %}
+{% from "../badge/large/macro.njk" import nhsappBadgeLarge %}
+{% from "../../styles/icon/macro.njk" import nhsappIcon %}
 
 {% set hasBadgeLarge = true if params.badgeLarge.count > 1 %}
 

--- a/src/styles/icon/icons.njk
+++ b/src/styles/icon/icons.njk
@@ -1,55 +1,55 @@
 {% macro account() %}
-  {% include "icons/account.svg" %}
+  {% include "../../assets/icons/account.svg" %}
 {% endmacro %}
 
 {% macro chevronRight() %}
-  {% include "icons/chevron-right.svg" %}
+  {% include "../../assets/icons/chevron-right.svg" %}
 {% endmacro %}
 
 {% macro crossFilled() %}
-  {% include "icons/cross-filled.svg" %}
+  {% include "../../assets/icons/cross-filled.svg" %}
 {% endmacro %}
 
 {% macro cross() %}
-  {% include "icons/cross.svg" %}
+  {% include "../../assets/icons/cross.svg" %}
 {% endmacro %}
 
 {% macro heartFilled() %}
-  {% include "icons/heart-filled.svg" %}
+  {% include "../../assets/icons/heart-filled.svg" %}
 {% endmacro %}
 
 {% macro heart() %}
-  {% include "icons/heart.svg" %}
+  {% include "../../assets/icons/heart.svg" %}
 {% endmacro %}
 
 {% macro help() %}
-  {% include "icons/help.svg" %}
+  {% include "../../assets/icons/help.svg" %}
 {% endmacro %}
 
 {% macro homeFilled() %}
-  {% include "icons/home-filled.svg" %}
+  {% include "../../assets/icons/home-filled.svg" %}
 {% endmacro %}
 
 {% macro home() %}
-  {% include "icons/home.svg" %}
+  {% include "../../assets/icons/home.svg" %}
 {% endmacro %}
 
 {% macro messagesFilled() %}
-  {% include "icons/messages-filled.svg" %}
+  {% include "../../assets/icons/messages-filled.svg" %}
 {% endmacro %}
 
 {% macro messages() %}
-  {% include "icons/messages.svg" %}
+  {% include "../../assets/icons/messages.svg" %}
 {% endmacro %}
 
 {% macro messagesUnreadFilled() %}
-  {% include "icons/messages-unread-filled.svg" %}
+  {% include "../../assets/icons/messages-unread-filled.svg" %}
 {% endmacro %}
 
 {% macro messagesUnread() %}
-  {% include "icons/messages-unread.svg" %}
+  {% include "../../assets/icons/messages-unread.svg" %}
 {% endmacro %}
 
 {% macro switchProfile() %}
-  {% include "icons/switch-profile.svg" %}
+  {% include "../../assets/icons/switch-profile.svg" %}
 {% endmacro %}

--- a/src/styles/icon/macro.njk
+++ b/src/styles/icon/macro.njk
@@ -1,4 +1,4 @@
-{% import "icon/icons.njk" as iconHtml %}
+{% import "../icon/icons.njk" as iconHtml %}
 
 {% macro nhsappIcon(iconName) %}
   {{ iconHtml[iconName]() }}


### PR DESCRIPTION
While adding NHS App components to the NHS HTML prototype using the Nunjucks macro: 

```
{% from "nhsapp/components/card/macro.njk" import nhsappCard %}

{{ nhsappCard({
  title: 'Request repeat prescriptions',
  href: '#'
}) }}

```

It threw up errors for the card links component (all other components worked as expected):

## Error 1

Couldn't find the badge macro.

```
Template render error: (/Users/davidhunter/Documents/prototypes/nhs-app-design-styles-components-patterns/node_modules/nhsapp-frontend/dist/nhsapp/components/card/card.njk)
Error: template not found: badge/large/macro.njk
```
### Fix

Prefixing the path with `../`:

`{% from "../badge/large/macro.njk" import nhsappBadgeLarge %}`

## Error 2

Couldn't find the icons macro.

```
Template render error: (/Users/davidhunter/Documents/prototypes/nhs-app-design-styles-components-patterns/node_modules/nhsapp-frontend/dist/nhsapp/components/card/card.njk)
Error: template not found: icon/macro.njk
```
### Fix

Prefixing the paths with `../../` and `../`:

`{% from "../../styles/icon/macro.njk" import nhsappIcon %}`

`{% import "../icon/icons.njk" as iconHtml %}`

## Error 3

Couldn't find the icon svgs.

```
Template render error: (/Users/davidhunter/Documents/prototypes/nhs-app-design-styles-components-patterns/node_modules/nhsapp-frontend/dist/nhsapp/components/card/card.njk)
Error: template not found: icons/chevron-right.svg
```
### Fix

Prefixing all the icons with `../../assets/`:

{% include "../../assets/icons/account.svg" %}

## Summary

Updating the paths in the macros fixes the problem:

<img width="1044" alt="Screenshot 2024-08-22 at 11 20 16" src="https://github.com/user-attachments/assets/d4f265de-820d-46f2-b318-76974aa4ce58">

Is it the best solution? Is there a smarter way to do this?