### PR TITLE
Minor suggested content changes to the components landing page.

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -2,8 +2,10 @@
 layout: layouts/component.njk
 isIndex: true
 title: NHS App design components
-description: These are components designed specifically for the needs of NHS App users and are not yet in the NHS design system.
+description: These are components designed specifically for the needs of NHS App users. They are not yet in the NHS design system.
 ---
+
+## Finding the component you need 
 
 Check the [NHS design system](https://service-manual.nhs.uk/design-system) to see if the component you need is already being used across the NHS.
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -5,7 +5,7 @@ title: NHS App design components
 description: These are components designed specifically for the needs of NHS App users. They are not yet in the NHS design system.
 ---
 
-## Finding the component you need 
+## Finding the component you need
 
 Check the [NHS design system](https://service-manual.nhs.uk/design-system) to see if the component you need is already being used across the NHS.
 


### PR DESCRIPTION
- Split the intro text beneath the heading into two sentences, to make it slightly easier to digest.

- Added a 'Finding the component you need' H2 above the initial body text. This might help to make clear which scenario the instructions in the body content are relevant to?