### PR TITLE
Update 'Get started' layout spacing

### DIFF
--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -38,7 +38,7 @@
 {% endset %}
 
 {% block main %}
-  <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-7">
+  <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
     {{ title }}
   </h1>
   {{ content | safe }}


### PR DESCRIPTION
To make it consistent with the other page layouts.