### PR TITLE
Remove extra spacing beneath images

### DIFF
--- a/docs/assets/css/_content.scss
+++ b/docs/assets/css/_content.scss
@@ -1,6 +1,7 @@
 .app-content {
   img {
     border: nhsuk-spacing(1) solid $app-img-border-color;
+    display: block; // To remove extra spacing beneath images
     max-width: 100%; // So images do not break the container
   }
 }


### PR DESCRIPTION
Added `display: block` to images to correct spacing between images and text.

## Before

<img width="730" alt="Screenshot 2024-10-09 at 12 08 19" src="https://github.com/user-attachments/assets/c5a559cf-6ae9-4530-8b7b-9ad34d885611">

## After

<img width="731" alt="Screenshot 2024-10-09 at 12 08 05" src="https://github.com/user-attachments/assets/f6a3ab85-5393-40e7-a736-d01326d6fd49">
