### PR TITLE
Change of example wording

### DIFF
--- a/docs/components/card-links.md
+++ b/docs/components/card-links.md
@@ -42,7 +42,7 @@ Only use this variation if you have found a user need for more detailed links on
 
 ### Using icons
 
-[Icons](/components/icons/) may help users to understand the meaning of a card link. We currently only use this variation for “Switch profiles” and “Messages” links on the homepage.
+[Icons](/components/icons/) may help users to understand the meaning of a card link. We currently only use this variation for “Manage health services for others” and “Messages” links on the homepage.
 
 {% example "cards/card-link-icon.njk" %}
 


### PR DESCRIPTION
We should change "Switch profiles" to "Manage health services for others" in the relevant guidance text and coded example on this page, to reflect a recent change in app content. 