### PR TITLE
Fix code syntax highlight colour contrast

### DIFF
--- a/docs/assets/css/_code-colours.scss
+++ b/docs/assets/css/_code-colours.scss
@@ -1,0 +1,46 @@
+// Prism JS colour overrides to make accessible
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #595959;
+}
+
+.token.punctuation {
+  color: #595959;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #558000;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #9a6e3a;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #005d85;
+}
+
+.token.function,
+.token.class-name {
+  color: #d93656;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #a36a00;
+}

--- a/docs/assets/css/app.scss
+++ b/docs/assets/css/app.scss
@@ -13,6 +13,7 @@
 @import "node_modules/nhsuk-frontend/packages/components/button/button";
 
 @import "node_modules/prismjs/themes/prism";
+@import "docs/assets/css/code-colours";
 
 // Import all styles from the NHS App frontend library
 @import "src/all";


### PR DESCRIPTION
Added `_code-colours.scss` to override prism.js colours.

Fixes https://github.com/nhsuk/nhsapp-frontend/issues/186

<img width="1212" alt="Screenshot 2024-12-11 at 14 31 56" src="https://github.com/user-attachments/assets/eef78d6b-fe04-4b41-b49b-e1c04a5f275d" />
<img width="1218" alt="Screenshot 2024-12-11 at 14 31 42" src="https://github.com/user-attachments/assets/349e1c2e-e284-44bb-8d28-aa82e492ccea" />
