### PR TITLE
Updated what's new section

### DIFF
--- a/docs/index.njk
+++ b/docs/index.njk
@@ -31,8 +31,8 @@
           <div class="nhsuk-grid-column-full">
             <div class="nhsuk-u-reading-width">
               <h2>What's new</h2>
-              <p>24 October 2024: We've released NHS App frontend 2.2.0.</p>
-              <p>This release included adding new <a href="/components/icons/">icons</a>.</p>
+              <p>19 December 2024: We've released NHS App frontend 2.3.0.</p>
+              <p>This release included adding a new <a href="/components/buttons#secondary-button">secondary button</a> and <a href="/components/panel/">panel</a> component.</p>
               <p>Read the <a href="https://github.com/nhsuk/nhsapp-frontend/releases" class="nhsuk-link--no-visited-state">full release notes</a> to see what's changed.</p>
             </div>
           </div>


### PR DESCRIPTION
Updated the 'What's new' section on the home page with the new release (v2.3.0)