### PR TITLE
Add homepage pattern guidance

### DIFF
--- a/docs/_includes/layouts/pattern.njk
+++ b/docs/_includes/layouts/pattern.njk
@@ -41,6 +41,11 @@
   <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
     {{ title }}
   </h1>
+  {% if pageNotice %}
+    <div class="nhsuk-inset-text">
+      <p>{{ pageNotice }}</p>
+    </div>
+  {% endif %}
   <p>{{ description }}</p>
   {{ content | safe }}
   {% if tags and "pattern" in tags %}

--- a/docs/examples/homepage/homepage-native.njk
+++ b/docs/examples/homepage/homepage-native.njk
@@ -1,0 +1,131 @@
+---
+layout: layouts/example-full-page-mobile.njk
+mobile: true
+hub: home
+title: Homepage native
+figmaLink: 
+vueLink: 
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCardGroup %}
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+{% from "nhsapp/styles/section-heading/macro.njk" import nhsappSectionHeading %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+
+    <div class="nhsuk-u-margin-bottom-7 nhsuk-u-padding-top-4">
+      <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" focusable="false" viewBox="0 0 40 16" height="40" width="80" aria-describedby="nhs-logo-title" role="img">
+        <title id="nhs-logo-title">NHS</title>
+        <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
+        <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8
+        9H1.1M17.3 1.5h3.6l-1
+        4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2
+        5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4
+        0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3
+        4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7
+        3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+      </svg>
+      <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-2">
+        <span class="app-greeting">Good morning</span>, 
+        <!-- Inline CSS added to sentence case the users name but need to check with nav team to see if we need to do this or not -->
+        <span style="display: block; text-transform: capitalize; word-wrap: break-word;">mary swanson</span>
+      </h1>
+      <p class="nhsuk-heading-s nhsuk-u-margin-bottom-0">
+        NHS number:
+        <span class="nhsuk-u-font-weight-normal">123 456 7890</span>
+      </p>
+    </div>
+
+    {{ nhsappSectionHeading({
+      headingText: "Services",
+      linkText: "View all",
+      linkUrl: "#",
+      linkAriaLabel: "View all services"
+    }) }}
+
+    {{ nhsappCardGroup({
+      stacked: true,
+      cards: [
+        {
+          title: "Request medicines",
+          href: "#"
+        },
+        {
+          title: "Check if you need urgent medical help using 111 online",
+          href: "#"
+        }
+      ]
+    }) }}
+
+    {{ nhsappSectionHeading({
+      headingText: "Your health",
+      linkText: "View all",
+      linkUrl: "#",
+      linkAriaLabel: "View all your health"
+    }) }}
+
+    {{ nhsappCardGroup({
+      stacked: true,
+      cards: [
+        {
+          title: "GP health record",
+          href: "#"
+        },
+        {
+          title: "View and manage prescriptions",
+          href: "#"
+        },
+        {
+          title: "Upcoming and past appointments",
+          href: "#"
+        }
+      ]
+    }) }}
+
+    {{ nhsappSectionHeading({
+      headingText: "Messages"
+    }) }}
+
+    {% if data['messages'] > 0 %}
+      {{ nhsappCardGroup({
+        stacked: true,
+        cards: [
+          {
+            title: 'View your messages',
+            href: '#',
+            prefixIcon: 'messagesUnread',
+            linkAriaLabel: 'Messages, you have ' + data['messages'] + ' unread messages',
+            badgeLarge: {
+              count: data['messages'],
+              label: 'unread messages',
+              ariaHidden: true
+            }
+          }
+        ]
+      }) }}
+    {% else %}
+      {{ nhsappCardGroup({
+        stacked: true,
+        cards: [
+          {
+            title: 'View your messages',
+            href: '#',
+            prefixIcon: 'messages'
+          }
+        ]
+      }) }}
+    {% endif %}
+
+    {{ nhsappSectionHeading({
+      headingText: "Account"
+    }) }}
+
+    {{ nhsappCard({
+      title: 'Manage services for another person',
+      href: '#',
+      prefixIcon: 'switchProfile'
+    }) }}
+
+  </div>
+</div>

--- a/docs/examples/homepage/homepage-native.njk
+++ b/docs/examples/homepage/homepage-native.njk
@@ -15,7 +15,7 @@ vueLink:
   <div class="nhsuk-grid-column-full">
 
     <div class="nhsuk-u-margin-bottom-7 nhsuk-u-padding-top-4">
-      <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" focusable="false" viewBox="0 0 40 16" height="40" width="80" aria-describedby="nhs-logo-title" role="img">
+      <svg class="nhsuk-logo nhsuk-u-margin-bottom-1" xmlns="http://www.w3.org/2000/svg" focusable="false" viewBox="0 0 40 16" height="28" width="70" aria-describedby="nhs-logo-title" role="img">
         <title id="nhs-logo-title">NHS</title>
         <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
         <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8

--- a/docs/examples/homepage/homepage-native.njk
+++ b/docs/examples/homepage/homepage-native.njk
@@ -48,7 +48,7 @@ vueLink:
       stacked: true,
       cards: [
         {
-          title: "Request medicines",
+          title: "Request repeat prescriptions",
           href: "#"
         },
         {

--- a/docs/examples/homepage/homepage-web.njk
+++ b/docs/examples/homepage/homepage-web.njk
@@ -1,0 +1,119 @@
+---
+layout: layouts/example-full-page-web.njk
+hub: home
+title: Homepage web
+figmaLink: 
+vueLink: 
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCardGroup %}
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+{% from "nhsapp/styles/section-heading/macro.njk" import nhsappSectionHeading %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+
+    <div class="nhsuk-u-margin-bottom-7">
+      <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-2">
+        <span class="app-greeting">Good morning</span>, 
+        <!-- Inline CSS added to sentence case the users name but need to check with nav team to see if we need to do this or not -->
+        <span style="display: block; text-transform: capitalize; word-wrap: break-word;">mary swanson</span>
+      </h1>
+      <p class="nhsuk-heading-s nhsuk-u-margin-bottom-0">
+        NHS number:
+        <span class="nhsuk-u-font-weight-normal">123 456 7890</span>
+      </p>
+    </div>
+
+    {{ nhsappSectionHeading({
+      headingText: "Services",
+      linkText: "View all",
+      linkUrl: "#",
+      linkAriaLabel: "View all services"
+    }) }}
+
+    {{ nhsappCardGroup({
+      stacked: true,
+      cards: [
+        {
+          title: "Request medicines",
+          href: "#"
+        },
+        {
+          title: "Check if you need urgent medical help using 111 online",
+          href: "#"
+        }
+      ]
+    }) }}
+
+    {{ nhsappSectionHeading({
+      headingText: "Your health",
+      linkText: "View all",
+      linkUrl: "#",
+      linkAriaLabel: "View all your health"
+    }) }}
+
+    {{ nhsappCardGroup({
+      stacked: true,
+      cards: [
+        {
+          title: "GP health record",
+          href: "#"
+        },
+        {
+          title: "View and manage prescriptions",
+          href: "#"
+        },
+        {
+          title: "Upcoming and past appointments",
+          href: "#"
+        }
+      ]
+    }) }}
+
+    {{ nhsappSectionHeading({
+      headingText: "Messages"
+    }) }}
+
+    {% if data['messages'] > 0 %}
+      {{ nhsappCardGroup({
+        stacked: true,
+        cards: [
+          {
+            title: 'View your messages',
+            href: '#',
+            prefixIcon: 'messagesUnread',
+            linkAriaLabel: 'Messages, you have ' + data['messages'] + ' unread messages',
+            badgeLarge: {
+              count: data['messages'],
+              label: 'unread messages',
+              ariaHidden: true
+            }
+          }
+        ]
+      }) }}
+    {% else %}
+      {{ nhsappCardGroup({
+        stacked: true,
+        cards: [
+          {
+            title: 'View your messages',
+            href: '#',
+            prefixIcon: 'messages'
+          }
+        ]
+      }) }}
+    {% endif %}
+
+    {{ nhsappSectionHeading({
+      headingText: "Account"
+    }) }}
+
+    {{ nhsappCard({
+      title: 'Manage services for another person',
+      href: '#',
+      prefixIcon: 'switchProfile'
+    }) }}
+
+  </div>
+</div>

--- a/docs/examples/homepage/homepage-web.njk
+++ b/docs/examples/homepage/homepage-web.njk
@@ -36,7 +36,7 @@ vueLink:
       stacked: true,
       cards: [
         {
-          title: "Request medicines",
+          title: "Request repeat prescriptions",
           href: "#"
         },
         {

--- a/docs/patterns/homepage.md
+++ b/docs/patterns/homepage.md
@@ -11,6 +11,8 @@ tags:
 
 ## The structure of the homepage
 
+{% example "homepage/homepage-web.njk" %}
+
 ### Dynamic page title
 
 This main heading includes a greeting that changes depending on the time of day. Research suggested this helps the app feel more personal to users.
@@ -26,8 +28,6 @@ Selecting one of these card links takes a user either directly into the start of
 ### Campaign card
 
 This card can be used to promote seasonal or topical campaigns such as COVID or flu vaccines, blood donation or being part of health research.
-
-{% example "homepage/homepage-web.njk" %}
 
 ## Proposing changes to the homepage
 

--- a/docs/patterns/homepage.md
+++ b/docs/patterns/homepage.md
@@ -1,7 +1,8 @@
 ---
 layout: layouts/pattern.njk
 title: Homepage
-description: The homepage has quick links to the most popular services of the NHS App. We work this out using Adobe Analytics and user feedback. The homepage also displays the name of the user and their NHS number. 
+description: The homepage shows the user their name and NHS number, and gives links to the most popular parts of the NHS App. We work this out using Adobe Analytics and user feedback. The homepage is also used to promote important health campaigns. 
+pageNotice: We’re currently reviewing the homepage as part of an information architecture review. 
 backlogID: 66
 tags:
   - pattern
@@ -11,32 +12,29 @@ tags:
 
 ## The structure of the homepage
 
-{% example "homepage/homepage-web.njk" %}
+### Main heading
 
-### Page heading
+This main heading includes the name of the user and a greeting that changes depending on the time of day. The name is sourced from the [personal demographics service (PDS)](https://digital.nhs.uk/services/personal-demographics-service) and may display in sentence case or block capitals depending on the data.
 
-This page heading includes a greeting that changes depending on the time of day. Research suggested this helps the app feel more personal to users.
+Below the name, we display the NHS number of the user. In research, participants regularly tell us they find having their NHS number here to be useful.
 
-### Section headings
+### Section heading
 
-Section headings are used to divide the card links across the page. This helps users understand how the journeys are organised within the app. The ‘view all’ links give users an in-page way to navigate to hub pages. In usability testing these links were the most common way that users proceeded from the homepage into the ‘Services’ and ‘Your health’ hubs.
+We use [section headings](/components/section-heading/) to separate links by which hub page of the app they come from. Alongside these section headings, ‘View all’ links lead to the relevant hub page.
 
 ### Card links
 
-Selecting one of these card links takes a user either directly into the start of a journey, or deeper into the app to a sub-hub.
+[Card links](/components/card-links/) on the page lead either directly to the start of a journey, or to a hub page.
 
 ### Campaign card
 
-This card can be used to promote seasonal or topical campaigns such as COVID or flu vaccines, blood donation or being part of health research.
+The campaign card promotes public health messaging agreed on by the senior leadership team of the NHS App that:
+
+- is relevant to most NHS App users
+- has an onward digital journey that meets our [usability and accessibility standards](https://digital.nhs.uk/services/nhs-app/how-to-integrate-with-the-nhs-app/standards-for-nhs-app-integration)
 
 ## Proposing changes to the homepage
 
-We are careful to limit the number of links that are shown in the homepage. We need to ensure that users can quickly scan through the page and access the most popular features of the NHS App.
+We’re careful to limit the number of links on the homepage. We need to make sure users can quickly scan through the page and access popular features.
 
-The Navigation and Onboarding Team maintains and updates the homepage. We regularly review and test the selection of links displayed. If you would like to suggest changes to the homepage, please contact the team.
-
-## Research
-
-In our research, users were able to complete a variety of tasks successfully from the starting point of the homepage. In one unmoderated usability test where people were tasked with booking an appointment for a relative, 90% completed the task successfully and all participants selected the correct onward link from the homepage.
-
-In research we also found that users perceived the display of personal information, particularly their NHS number, to be valuable.
+The Navigation and Onboarding team maintains and updates the homepage. We regularly review and test the selection of links that are included. If you'd like to suggest changes to the homepage, please contact us on Slack.

--- a/docs/patterns/homepage.md
+++ b/docs/patterns/homepage.md
@@ -13,13 +13,13 @@ tags:
 
 {% example "homepage/homepage-web.njk" %}
 
-### Dynamic page title
+### Page heading
 
-This main heading includes a greeting that changes depending on the time of day. Research suggested this helps the app feel more personal to users.
+This page heading includes a greeting that changes depending on the time of day. Research suggested this helps the app feel more personal to users.
 
-### Section titles with ‘view all’ links
+### Section headings
 
-Section titles are used to divide the card links across the page. This helps users understand how the journeys are organised within the app. The ‘view all’ links give users an in-page way to navigate to hub pages. In usability testing these links were the most common way that users proceeded from the homepage into the ‘Services’ and ‘Your health’ hubs.
+Section headings are used to divide the card links across the page. This helps users understand how the journeys are organised within the app. The ‘view all’ links give users an in-page way to navigate to hub pages. In usability testing these links were the most common way that users proceeded from the homepage into the ‘Services’ and ‘Your health’ hubs.
 
 ### Card links
 
@@ -33,7 +33,7 @@ This card can be used to promote seasonal or topical campaigns such as COVID or 
 
 We are careful to limit the number of links that are shown in the homepage. We need to ensure that users can quickly scan through the page and access the most popular features of the NHS App.
 
-The Navigation and Onboarding Team maintains and updates the homepage. We regularly review and test the selection of links displayed. If you would like to suggest changes to the homepage, please contact us.
+The Navigation and Onboarding Team maintains and updates the homepage. We regularly review and test the selection of links displayed. If you would like to suggest changes to the homepage, please contact the team.
 
 ## Research
 

--- a/docs/patterns/homepage.md
+++ b/docs/patterns/homepage.md
@@ -1,0 +1,42 @@
+---
+layout: layouts/pattern.njk
+title: Homepage
+description: The homepage has quick links to the most popular services of the NHS App. We work this out using Adobe Analytics and user feedback. The homepage also displays the name of the user and their NHS number. 
+backlogID: 66
+tags:
+  - pattern
+---
+
+{% example "homepage/homepage-native.njk" %}
+
+## The structure of the homepage
+
+### Dynamic page title
+
+This main heading includes a greeting that changes depending on the time of day. Research suggested this helps the app feel more personal to users.
+
+### Section titles with ‘view all’ links
+
+Section titles are used to divide the card links across the page. This helps users understand how the journeys are organised within the app. The ‘view all’ links give users an in-page way to navigate to hub pages. In usability testing these links were the most common way that users proceeded from the homepage into the ‘Services’ and ‘Your health’ hubs.
+
+### Card links
+
+Selecting one of these card links takes a user either directly into the start of a journey, or deeper into the app to a sub-hub.
+
+### Campaign card
+
+This card can be used to promote seasonal or topical campaigns such as COVID or flu vaccines, blood donation or being part of health research.
+
+{% example "homepage/homepage-web.njk" %}
+
+## Proposing changes to the homepage
+
+We are careful to limit the number of links that are shown in the homepage. We need to ensure that users can quickly scan through the page and access the most popular features of the NHS App.
+
+The Navigation and Onboarding Team maintains and updates the homepage. We regularly review and test the selection of links displayed. If you would like to suggest changes to the homepage, please contact us.
+
+## Research
+
+In our research, users were able to complete a variety of tasks successfully from the starting point of the homepage. In one unmoderated usability test where people were tasked with booking an appointment for a relative, 90% completed the task successfully and all participants selected the correct onward link from the homepage.
+
+In research we also found that users perceived the display of personal information, particularly their NHS number, to be valuable.


### PR DESCRIPTION
Adding homepage guidance to the design system with coded examples.

## Draft guidance - v1

![image](https://github.com/user-attachments/assets/f8349ac3-29a4-4201-9ed1-10b00fb8171e)
