### PR TITLE
Update side nav heading structure

### DIFF
--- a/docs/_includes/layouts/partials/side-navigation.njk
+++ b/docs/_includes/layouts/partials/side-navigation.njk
@@ -1,10 +1,11 @@
 {% macro appSideNavigation(params) %}
   <nav class="app-side-navigation {{- ' ' + params.classes if params.classes }}" {%- if (params.label) %} aria-label="{{ params.label }}"{% endif %} {% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    <h2 class="nhsuk-u-visually-hidden">Pages in this section</h2>
     {%- if params.sections %}
       {%- for section in params.sections %}
-        <h{{ section.heading.headingLevel | default(4) }} class="app-side-navigation__title {{- ' ' + section.heading.classes if section.heading.classes }}"{% for attribute, value in section.heading.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+        <h{{ section.heading.headingLevel | default(3) }} class="app-side-navigation__title {{- ' ' + section.heading.classes if section.heading.classes }}"{% for attribute, value in section.heading.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
           {{- section.heading.html | safe if section.heading.html else section.heading.text -}}
-        </h{{ section.heading.headingLevel | default(4) }}>
+        </h{{ section.heading.headingLevel | default(3) }}>
         <ul class="app-side-navigation__list">
           {%- for item in section.items %}
             {% include "./side-navigation-item.njk" %}


### PR DESCRIPTION
## What

- changed the side nav default heading to a `h3`
- added a visually hidden `h2` (same as the gov design system).

## Why

The side nav heading elements were not in a sequentially-descending order.

<img width="994" alt="Screenshot 2025-01-23 at 12 28 48" src="https://github.com/user-attachments/assets/11720db0-fac1-4645-a283-da4a35225a93" />

---

### GOV.UK code example:
<img width="504" alt="Screenshot 2025-01-23 at 12 29 02" src="https://github.com/user-attachments/assets/81f55f32-c07f-4a2d-8667-a8e457310e56" />

