### PR TITLE
Updated text labels on tag examples

### DIFF
--- a/docs/examples/tags/tag.njk
+++ b/docs/examples/tags/tag.njk
@@ -21,7 +21,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Started",
+          text: "Status",
           classes: "nhsapp-tag--white"
         })}}
       </td>
@@ -32,7 +32,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Not started",
+          text: "Status",
           classes: "nhsapp-tag--grey"
         })}}
       </td>
@@ -43,7 +43,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "New",
+          text: "Status",
           classes: "nhsapp-tag--green"
         })}}
       </td>
@@ -54,7 +54,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Active",
+          text: "Status",
           classes: "nhsapp-tag--aqua-green"
         })}}
       </td>
@@ -65,7 +65,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Pending",
+          text: "Status",
           classes: "nhsapp-tag--blue"
         })}}
       </td>
@@ -76,7 +76,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Received",
+          text: "Status",
           classes: "nhsapp-tag--purple"
         })}}
       </td>
@@ -87,7 +87,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Sent",
+          text: "Status",
           classes: "nhsapp-tag--pink"
         })}}
       </td>
@@ -98,7 +98,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Rejected",
+          text: "Status",
           classes: "nhsapp-tag--red"
         })}}
       </td>
@@ -109,7 +109,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Declined",
+          text: "Status",
           classes: "nhsapp-tag--orange"
         })}}
       </td>
@@ -120,7 +120,7 @@ vueLink: https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path
       </td>
       <td class="nhsuk-table__cell">
         {{ nhsappTag({
-          text: "Delayed",
+          text: "Status",
           classes: "nhsapp-tag--yellow"
         })}}
       </td>


### PR DESCRIPTION
Updated the text for our tag examples to consistently read "Status". This mirrors the approach the Scottish Government have taken on their design system. It should help to avoid designers thinking we have particular assigned text labels for different coloured tags.