### PR TITLE
Add card footer link & secondary card link

### DIFF
--- a/docs/components/card-links.md
+++ b/docs/components/card-links.md
@@ -62,6 +62,16 @@ If a page has a long list of card links, consider breaking them up using heading
 
 {% example "cards/card-group-headings.njk" %}
 
+### Secondary card links
+
+Use secondary card links on hub pages to signpost groups of information on less important topics.
+
+{% example "cards/card-link-secondary.njk" %}
+
+Use them below primary card links which signpost more important information.
+
+{% example "cards/card-link-secondary-stacked.njk" %}
+
 ## Content guidance
 
 Aim to use active phrasing for card link text. This means starting the link text with a verb. For example: "Request repeat prescriptions" and "Check for available GP appointments". This follows content guidance on links and helps users to understand the action they can take.

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -1,0 +1,10 @@
+---
+layout: layouts/component.njk
+title: Card
+---
+
+{% example "cards/card.njk" %}
+
+{% example "cards/card-footer.njk" %}
+
+{% example "cards/card-footer-link.njk" %}

--- a/docs/examples/cards/card-footer-link.njk
+++ b/docs/examples/cards/card-footer-link.njk
@@ -17,6 +17,6 @@ vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?pat
   ",
   footer: { 
     href: "#",
-    title: "Manage health services for others"
+    text: "Manage health services for others"
   }
 }) }} 

--- a/docs/examples/cards/card-footer-link.njk
+++ b/docs/examples/cards/card-footer-link.njk
@@ -1,0 +1,22 @@
+---
+layout: layouts/example.njk
+title: Card with footer link
+figmaLink: "https://www.figma.com/file/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?type=design&node-id=128%3A7303&mode=design&t=DLiyCHcTTAYkEDa0-1"
+vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhscardbase--docs"
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+
+{{ nhsappCard({
+  title: 'Mary Swanson',
+  titleHeadingLevel: '2',
+  titleClasses: 'nhsuk-u-font-size-32',
+  html: "
+    <p class='nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-1'>Date of birth: 15 March 1984</p>
+    <p>NHS Number: 123 456 7890</p>
+  ",
+  footer: { 
+    href: "#",
+    title: "Manage health services for others"
+  }
+}) }} 

--- a/docs/examples/cards/card-link-secondary-stacked.njk
+++ b/docs/examples/cards/card-link-secondary-stacked.njk
@@ -1,0 +1,47 @@
+---
+layout: layouts/example.njk
+title: Card link secondary stacked
+figmaLink: ""
+vueLink: ""
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCardGroup %}
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+{% from "nhsapp/styles/section-heading/macro.njk" import nhsappSectionHeading %}
+
+{{ nhsappSectionHeading({
+  headingText: "Settings"
+}) }}
+
+{{ nhsappCardGroup({
+  stacked: true,
+  cards: [
+    {
+      title: 'Login and security',
+      href: '#'
+    },
+    {
+      title: 'Face ID',
+      href: '#'
+    }
+  ]
+}) }}
+
+{{ nhsappSectionHeading({
+  headingText: "About the NHS App"
+}) }}
+
+{{ nhsappCardGroup({
+  stacked: true,
+  classes: 'nhsapp-cards--secondary',
+  cards: [
+    {
+      title: 'Privacy and legal policies',
+      href: '#'
+    },
+    {
+      title: 'Join our user research panel',
+      href: '#'
+    }
+  ]
+}) }}

--- a/docs/examples/cards/card-link-secondary.njk
+++ b/docs/examples/cards/card-link-secondary.njk
@@ -1,0 +1,14 @@
+---
+layout: layouts/example.njk
+title: Card link secondary
+figmaLink: ""
+vueLink: ""
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+
+{{ nhsappCard({
+  title: 'Privacy and legal policies',
+  href: '#',
+  classes: 'nhsapp-card--secondary'
+}) }}

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -102,7 +102,7 @@ $card-border-hover-color: $color_nhsuk-grey-3;
       margin-bottom: 0;
     }
 
-    &--link {
+    &--with-link {
       align-items: center;
       display: flex;
       gap: nhsuk-spacing(3);

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -116,6 +116,12 @@ $card-border-hover-color: $color_nhsuk-grey-3;
   }
 }
 
+// secondary card
+.nhsapp-cards--secondary .nhsapp-card,
+.nhsapp-card--secondary {
+  background: transparent;
+}
+
 // card group
 .nhsapp-cards {
   @include nhsuk-responsive-margin(5, "bottom");

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -101,6 +101,18 @@ $card-border-hover-color: $color_nhsuk-grey-3;
     :last-child {
       margin-bottom: 0;
     }
+
+    &--link {
+      align-items: center;
+      display: flex;
+      gap: nhsuk-spacing(3);
+      justify-content: flex-start;
+      position: relative;
+
+      .nhsapp-icon {
+        margin-left: auto;
+      }
+    }
   }
 }
 

--- a/src/components/card/card-group.njk
+++ b/src/components/card/card-group.njk
@@ -7,6 +7,8 @@
   {% for cardItem in params.cards %}
     {{ nhsappCard({
       title: cardItem.title,
+      titleClasses: cardItem.titleClasses,
+      titleHeadingLevel: cardItem.titleHeadingLevel,
       href: cardItem.href,
       html: cardItem.html,
       classes: cardItem.classes,

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -20,10 +20,14 @@
           {{ params.aboveContent.html | safe }}
         </div>
       {%- endif -%}
-      {%- if params.readOnly -%}
-        <p class="nhsapp-card__title">{{ params.title }}</p>
+      {%- if params.readOnly or params.footer.href -%}
+        {%- if params.titleHeadingLevel -%}
+          <h{{ params.titleHeadingLevel }} class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">{{ params.title }}</h{{ params.titleHeadingLevel }}>
+        {%- else -%}
+          <p class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">{{ params.title }}</p>
+        {%- endif -%}
       {%- else -%}
-        <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
+        <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state {{ params.titleClasses if params.titleClasses }}" 
       {%- if params.linkAriaLabel %} aria-label="{{ params.linkAriaLabel }}" {% endif %}>
           {{ params.title }}
         </a>
@@ -44,13 +48,22 @@
         ariaHidden: params.badgeLarge.ariaHidden
       }) }}
     {% endif %}
-    {%- if not params.readOnly -%}
+    {%- if params.readOnly or params.footer.href -%}
+    {%- else -%}
       {{ nhsappIcon('chevronRight') }}
     {%- endif -%}
   </div>
   {%- if params.footer.html -%}
     <div class="nhsapp-card__footer">
       {{ params.footer.html | safe }}
+    </div>
+  {%- elif params.footer.href -%}
+    <div class="nhsapp-card__footer nhsapp-card__footer--link">
+      <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
+      {%- if params.footer.linkAriaLabel %} aria-label="{{ params.footer.linkAriaLabel }}" {% endif %}>
+          {{ params.footer.title }}
+      </a>
+      {{ nhsappIcon('chevronRight') }}
     </div>
   {%- endif -%}
 {%- if params.isListItem -%}

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -61,7 +61,7 @@
     <div class="nhsapp-card__footer nhsapp-card__footer--with-link">
       <a href="{{ params.footer.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
       {%- if params.footer.linkAriaLabel %} aria-label="{{ params.footer.linkAriaLabel }}" {% endif %}>
-          {{ params.footer.title }}
+          {{ params.footer.text }}
       </a>
       {{ nhsappIcon('chevronRight') }}
     </div>

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -58,7 +58,7 @@
       {{ params.footer.html | safe }}
     </div>
   {%- elif params.footer.href -%}
-    <div class="nhsapp-card__footer nhsapp-card__footer--link">
+    <div class="nhsapp-card__footer nhsapp-card__footer--with-link">
       <a href="{{ params.footer.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
       {%- if params.footer.linkAriaLabel %} aria-label="{{ params.footer.linkAriaLabel }}" {% endif %}>
           {{ params.footer.title }}

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -59,7 +59,7 @@
     </div>
   {%- elif params.footer.href -%}
     <div class="nhsapp-card__footer nhsapp-card__footer--link">
-      <a href="{{ params.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
+      <a href="{{ params.footer.href }}" class="nhsapp-card__link nhsuk-link--no-visited-state" 
       {%- if params.footer.linkAriaLabel %} aria-label="{{ params.footer.linkAriaLabel }}" {% endif %}>
           {{ params.footer.title }}
       </a>


### PR DESCRIPTION
## Description

- Updated card macro for footer link variant
- Added footer link example
- Added placeholder card guidance page (hidden from nav until guidance ready)

<img width="699" alt="Screenshot 2025-01-31 at 13 43 29" src="https://github.com/user-attachments/assets/c41fd621-cbe3-4411-a08a-758578ddbd5f" />

## Notes

On this PR, should we also add the: 
- colour (blue) variant CSS (for the identity card)?
- secondary card link styling?

<img width="371" alt="Screenshot 2025-01-31 at 13 41 32" src="https://github.com/user-attachments/assets/f833e3ce-60f8-4842-8f17-fbc5370ee591" />
