### PR TITLE
Bump `nhsuk-frontend` version `v9.2.0`

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,7 +21,8 @@ const nunjucksEnv = nunjucks.configure([
   'docs/assets',
 
   // NHS.UK frontend components
-  'node_modules/nhsuk-frontend/packages/components'
+  'node_modules/nhsuk-frontend/packages/components',
+  'node_modules/nhsuk-frontend/packages/macros'
 ])
 
 export default function (eleventyConfig) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,77 @@
 # NHS App Frontend Changelog
 
-## 0.1.0-alpha.0 (Prerelease) - 18 April 2024
+## `v3.0.0` - UNRELEASED
 
-:tada: **Initial release of the NHS App Frontend**
+### Breaking changes
+
+- Bumped `nhsuk-frontend` version to `v9.2.0` ([PR 241](https://github.com/nhsuk/nhsapp-frontend/pull/241)) - details are in the [nhsuk frontend release notes](https://github.com/nhsuk/nhsuk-frontend/releases)
+- Bumped `nhsuk-frontend` peer dependency version to `v9.0.0`
+
+### Components
+
+- Updated [Badge](https://design-system.nhsapp.service.nhs.uk/components/badge/) - removing small blue variant
+
+## `v2.3.0`
+
+### Fixes
+
+- Icons now use `rem` sizing to ensure consitency in different contexts
+
+### Components
+
+- New [Seconday Button](https://design-system.nhsapp.service.nhs.uk/components/buttons/) styling added
+- New [Confirmation Panel](https://design-system.nhsapp.service.nhs.uk/components/panel/) component
+
+## `v2.2.0`
+
+### Fixes
+
+- Badge count now displaying correctly when value is 1
+- Cards in combination with a section heading spacing now fixed
+- Added missing card param to Nunjucks macro `linkAriaLabel`
+
+### Styles
+
+New icons added. [See full commit](https://github.com/nhsuk/nhsapp-frontend/commit/201556e91df539d9ec6dce4eda50a0f478ed3b05) for list of icons.
+
+## `v2.1.0`
+
+Updates to guidance and the microsite
+
+### Fixes
+
+Card link with badge accessibility fix. Added option to provide `aria-hidden` to the badge when used with the card link. Plus, changed the badge HTML from a `span` to a `p`. This fixes issues we saw with MacOS Voiceover.
+
+### Components and styles
+
+- The card component now supports a footer section. The guidance for this will be coming very soon after this release
+- The card component now supports a "read only" view. The chevron icon is hidden and the title is no longer a link
+
+## `v2.0.1`
+
+### Fixes
+
+Create symlink to `docs/_includes` so that the docs can include anything in `src`
+
+### Breaking changes
+
+Prefixed all Nunjucks macros with `nhsapp`.
+
+> ~~`card`~~ > `nhsappCard`
+
+## `v1.2.0`
+
+### Components and styles
+
+- Button enhancements. Extending the `nhsuk-frontend` button styling to support default full width buttons on mobile.
+
+## `v1.1.0`
+
+Minor updates to guidance
+
+### Components and styles
+
+- Summary list now supports a two column display on mobile
 
 ## `v1.0.0` release of the NHS App Frontend package.
 
@@ -18,70 +87,6 @@ A collection of HTML, CSS, Nunjucks templates and guidance for the NHS App. Buil
 - Timeline
 - Top Navigation (native)
 
-## `v1.1.0`
+## 0.1.0-alpha.0 (Prerelease) - 18 April 2024
 
-Minor updates to guidance
-
-### Components and styles
-
-- Summary list now supports a two column display on mobile
-
-## `v1.2.0`
-
-### Components and styles
-
-- Button enhancements. Extending the `nhsuk-frontend` button styling to support default full width buttons on mobile.
-
-## `v2.0.1`
-
-### Fixes
-
-Create symlink to `docs/_includes` so that the docs can include anything in `src`
-
-### Breaking changes
-
-Prefixed all Nunjucks macros with `nhsapp`.
-
-> ~~`card`~~ > `nhsappCard`
-
-## `v2.1.0`
-
-Updates to guidance and the microsite
-
-### Fixes
-
-Card link with badge accessibility fix. Added option to provide `aria-hidden` to the badge when used with the card link. Plus, changed the badge HTML from a `span` to a `p`. This fixes issues we saw with MacOS Voiceover.
-
-### Components and styles
-
-- The card component now supports a footer section. The guidance for this will be coming very soon after this release
-- The card component now supports a "read only" view. The chevron icon is hidden and the title is no longer a link
-
-## `v2.2.0`
-
-### Fixes
-
-- Badge count now displaying correctly when value is 1
-- Cards in combination with a section heading spacing now fixed
-- Added missing card param to Nunjucks macro `linkAriaLabel`
-
-### Styles
-
-New icons added. [See full commit](https://github.com/nhsuk/nhsapp-frontend/commit/201556e91df539d9ec6dce4eda50a0f478ed3b05) for list of icons.
-
-## `v2.3.0`
-
-### Fixes
-
-- Icons now use `rem` sizing to ensure consitency in different contexts
-
-### Components
-
-- New [Seconday Button](https://design-system.nhsapp.service.nhs.uk/components/buttons/) styling added
-- New [Confirmation Panel](https://design-system.nhsapp.service.nhs.uk/components/panel/) component
-
-## `v2.4.0` - UNRELEASED
-
-### Components
-
-- Updated [Badge](https://design-system.nhsapp.service.nhs.uk/components/badge/) - removing small blue variant
+:tada: **Initial release of the NHS App Frontend**

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -3,6 +3,7 @@
 {% from 'breadcrumb/macro.njk' import breadcrumb %}
 {% from 'skip-link/macro.njk' import skipLink %}
 {% from "icon/macro.njk" import nhsappIcon %}
+{% from 'attributes.njk' import nhsukAttributes %}
 
 <!DOCTYPE html>
 <html lang="en" {% if htmlClasses %} class="{{ htmlClasses }}"{% endif %}>
@@ -76,12 +77,10 @@
         }}
       {% endblock %}
 
-      {% block breadcrumb %}
-      {% endblock %}
-
       {% block container %}
         <div class="nhsuk-width-container{% if containerClasses %} {{ containerClasses }}{% endif %}">
-          <main role="main" id="maincontent" class="nhsuk-main-wrapper{% if mainClasses %} {{ mainClasses }}{% endif %}">
+          {% block beforeContent %}{% endblock %}
+          <main role="main" id="maincontent" class="nhsuk-main-wrapper {% if mainClasses %} {{ mainClasses }}{% endif %}">
             {% block main %}
               {{ content | safe }}
             {% endblock main %}

--- a/docs/_includes/layouts/community.njk
+++ b/docs/_includes/layouts/community.njk
@@ -2,7 +2,7 @@
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
 
-{% block breadcrumb %}
+{% block beforeContent %}
   {% if title === "Community" %}
     {{ breadcrumb({
       href: "/",

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -2,7 +2,7 @@
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
 
-{% block breadcrumb %}
+{% block beforeContent %}
   {% if title === "Components" %}
     {{ breadcrumb({
       href: "/",

--- a/docs/_includes/layouts/example-full-page-mobile-not-logged-in.njk
+++ b/docs/_includes/layouts/example-full-page-mobile-not-logged-in.njk
@@ -3,7 +3,6 @@
 {% block skiplink %}{% endblock %}
 
 {% set htmlClasses = "app-html-background-color-grey-5" %}
-{% set mainClasses = "nhsuk-main-wrapper--s" %}
 
 {% block header %}
   {% include "layouts/partials/header-native.njk" %}

--- a/docs/_includes/layouts/example-full-page-web.njk
+++ b/docs/_includes/layouts/example-full-page-web.njk
@@ -1,7 +1,5 @@
 {% extends "./base.njk" %}
 
-{% set mainClasses = "nhsuk-main-wrapper--s" %}
-
 {% block header %}
   {% include "layouts/partials/header-web.njk" %}
 {% endblock %}

--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -2,7 +2,7 @@
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
 
-{% block breadcrumb %}
+{% block beforeContent %}
   {% if title === "Get started" %}
     {{ breadcrumb({
       href: "/",

--- a/docs/_includes/layouts/pattern.njk
+++ b/docs/_includes/layouts/pattern.njk
@@ -2,7 +2,7 @@
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
 
-{% block breadcrumb %}
+{% block beforeContent %}
   {% if title === "Patterns" %}
     {{ breadcrumb({
       href: "/",

--- a/docs/_includes/layouts/plain.njk
+++ b/docs/_includes/layouts/plain.njk
@@ -1,6 +1,6 @@
 {% extends "./base.njk" %}
 
-{% block breadcrumb %}
+{% block beforeContent %}
   {{ breadcrumb({
     href: "/",
     text: "Home"

--- a/docs/_includes/layouts/sidebar.njk
+++ b/docs/_includes/layouts/sidebar.njk
@@ -2,6 +2,7 @@
 
 {% block container %}
   <div class="nhsuk-width-container">
+    {% block beforeContent %}{% endblock %}
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-quarter">
         {% block sidebar_desktop %}
@@ -12,7 +13,7 @@
       </div>
 
       <div class="nhsuk-grid-column-three-quarters">
-        <main role="main" id="maincontent" class="nhsuk-main-wrapper app-content">
+        <main role="main" id="maincontent" class="nhsuk-main-wrapper nhsuk-main-wrapper--s app-content">
           {% block main %}
             {{ content | safe }}
           {% endblock main %}

--- a/docs/assets/css/app.scss
+++ b/docs/assets/css/app.scss
@@ -63,15 +63,6 @@ pre {
   }
 }
 
-// Frontend button colour overrides
-.nhsuk-button--reverse {
-  color: $color_nhsuk-black;
-
-  &:visited {
-    color: $color_nhsuk-black;
-  }
-}
-
 // Home page section
 .app-section {
   :last-child {

--- a/docs/assets/css/components/_header.scss
+++ b/docs/assets/css/components/_header.scss
@@ -3,24 +3,24 @@
   background-color: $app-brand-color;
 
   .nhsuk-header__navigation-link {
-    margin-right: 32px;
     padding-left: 0;
     padding-right: 0;
   }
 
   .nhsuk-header__menu-toggle--visible {
-    padding-right: 30px;
+    padding-right: 24px;
   }
 
   .nhsuk-header__drop-down {
     .nhsuk-header__navigation-link {
       padding: 12px 16px;
-      margin-right: 0;
+      margin: 0;
     }
   }
 
   .nhsuk-header__navigation-list {
     @include mq($from: desktop) {
+      gap: 32px;
       justify-content: flex-start;
     }
   }

--- a/docs/assets/css/components/_side-navigation.scss
+++ b/docs/assets/css/components/_side-navigation.scss
@@ -6,11 +6,12 @@
   @include nhsuk-font($size: 16);
 
   display: block;
-  padding: nhsuk-spacing(2) 0 0;
+  padding: nhsuk-spacing(5) 0 0;
 }
 
 .app-side-navigation__title {
   @include nhsuk-font($size: 19);
+
   color: $color_nhsuk-grey-1;
   font-weight: normal;
   margin: 0;
@@ -88,7 +89,7 @@
 }
 
 .app-side-navigation--mobile {
-  padding-bottom: nhsuk-spacing(4);
+  padding: nhsuk-spacing(4) 0;
 
   .app-side-navigation {
     padding: 0 0 nhsuk-spacing(3);
@@ -100,6 +101,10 @@
 
   .app-side-navigation--section {
     padding-top: nhsuk-spacing(3);
+  }
+
+  .app-side-navigation__title {
+    font-weight: bold;
   }
 
   .app-side-navigation__item {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
         "gulp-uglify": "^3.0.2",
         "gulp-zip": "^6.0.0",
         "markdown-it-anchor": "^9.0.1",
-        "nhsuk-frontend": "^9.1.0",
+        "nhsuk-frontend": "^9.2.0",
         "nunjucks": "^3.2.4",
         "prettier": "^3.2.5",
         "sass": "^1.74.1"
       },
       "peerDependencies": {
-        "nhsuk-frontend": "^9.1.0"
+        "nhsuk-frontend": "^9.0.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.1.0.tgz",
-      "integrity": "sha512-z2hcZDUDz12hjBTWLasq5lfX+sv2jwZFkUdip8qL9fBQ6qykyQFQ8PjWuBBgQN03IU0wMkV3BBLbwBjFiSxREQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.3.0.tgz",
+      "integrity": "sha512-XZqmZN8YMK/j5cHi7O5AEDigFzPPZJFhBOPkYO/kNIw6k3eveedfRZetgVzOVurI7GUQmWd9IF67eVwR8LFh7w==",
       "dev": true,
       "engines": {
         "node": ">=20.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
         "gulp-uglify": "^3.0.2",
         "gulp-zip": "^6.0.0",
         "markdown-it-anchor": "^9.0.1",
-        "nhsuk-frontend": "^8.1.1",
+        "nhsuk-frontend": "^9.1.0",
         "nunjucks": "^3.2.4",
         "prettier": "^3.2.5",
         "sass": "^1.74.1"
       },
       "peerDependencies": {
-        "nhsuk-frontend": "^8.0.0"
+        "nhsuk-frontend": "^9.1.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -1263,9 +1263,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3227,12 +3227,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3392,10 +3392,13 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.2.0.tgz",
-      "integrity": "sha512-qVMhgQqz0UD9D/sXqvllinge2WeGBwyBxdJAfcNxEvWl4oZ6FWCZbMFE9YCTqDjpfy9k2K251x8QJm1MssSA6Q==",
-      "dev": true
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.1.0.tgz",
+      "integrity": "sha512-z2hcZDUDz12hjBTWLasq5lfX+sv2jwZFkUdip8qL9fBQ6qykyQFQ8PjWuBBgQN03IU0wMkV3BBLbwBjFiSxREQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/node-retrieve-globals": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsapp-frontend",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "A CSS library built on top of nhsuk-frontend providing styles for the NHS App.",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "gulp-uglify": "^3.0.2",
     "gulp-zip": "^6.0.0",
     "markdown-it-anchor": "^9.0.1",
-    "nhsuk-frontend": "^8.1.1",
+    "nhsuk-frontend": "^9.1.0",
     "nunjucks": "^3.2.4",
     "prettier": "^3.2.5",
     "sass": "^1.74.1"
   },
   "peerDependencies": {
-    "nhsuk-frontend": "^8.0.0"
+    "nhsuk-frontend": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "gulp-uglify": "^3.0.2",
     "gulp-zip": "^6.0.0",
     "markdown-it-anchor": "^9.0.1",
-    "nhsuk-frontend": "^9.1.0",
+    "nhsuk-frontend": "^9.2.0",
     "nunjucks": "^3.2.4",
     "prettier": "^3.2.5",
     "sass": "^1.74.1"
   },
   "peerDependencies": {
-    "nhsuk-frontend": "^9.1.0"
+    "nhsuk-frontend": "^9.0.0"
   }
 }

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -21,7 +21,7 @@
 $nhsapp-border-width-panel: nhsuk-spacing(1);
 
 .nhsapp-panel {
-  @include nhsuk-typography-responsive(24);
+  @include nhsuk-typography-responsive(26);
   @include nhsuk-responsive-margin(4, "bottom");
 
   background: $color_nhsuk-green;


### PR DESCRIPTION
## Description

Bumped the version of the `nhsuk-frontend` to `v9.2.0`
- https://github.com/nhsuk/nhsapp-frontend/issues/175

Bump peer dependency `nhsuk-frontend` to `v9.0.0`

## Page layout changes

- added `{% from 'attributes.njk' import nhsukAttributes %}` to base page template (for component macros to work)
- changed `{% block breadcrumb %}{% endblock %}` to `{% block beforeContent %}{% endblock %}`
- moved `{% block beforeContent %}{% endblock %}` to within `container` before `main`
- removed `nhsuk-main-wrapper--s` class because `nhsuk-main-wrapper` padding has decreased from `40px` to `24px` on mobile

## Visual design changes

**Card links** font size on mobile changed from `18px` to `19px`

| Before | After |
| -------|-------|
| <img width="331" alt="Screenshot 2025-02-10 at 15 28 54" src="https://github.com/user-attachments/assets/a0b01af8-9e7d-4fbc-84e2-3f36873dfe77" /> | <img width="329" alt="Screenshot 2025-02-10 at 15 28 39" src="https://github.com/user-attachments/assets/0edbf3c4-7dea-4780-90c0-4b864d454f5f" /> |

**Section headings** font size on mobile changed from `18px` to `19px`

| Before | After |
| -------|-------|
| <img width="342" alt="Screenshot 2025-02-10 at 15 54 32" src="https://github.com/user-attachments/assets/c6cd75ab-6457-413c-be15-e77c67494da4" /> | <img width="340" alt="Screenshot 2025-02-10 at 15 53 57" src="https://github.com/user-attachments/assets/1892bed8-ae96-468f-975a-74e21a244275" /> |

## Other stuff to consider

- **global header (web)** - do we want to swap it for the new version? It changed in version 8 of the nhsuk-frontend but the app is using version 7