### PR TITLE
Add secondary card link guidance and examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS App Frontend Changelog
 
+## `v3.1.0` - UNRELEASED
+
+### Components
+
+- Added [secondary card link](/components/card-links/#secondary-card-links)
+
 ## `v3.0.0`
 
 ### Breaking changes

--- a/docs/components/card-links.md
+++ b/docs/components/card-links.md
@@ -62,6 +62,16 @@ If a page has a long list of card links, consider breaking them up using heading
 
 {% example "cards/card-group-headings.njk" %}
 
+### Secondary card links
+
+Use secondary card links on hub pages to signpost groups of information on less important topics.
+
+{% example "cards/card-link-secondary.njk" %}
+
+Use them below primary card links which signpost more important information.
+
+{% example "cards/card-link-secondary-stacked.njk" %}
+
 ## Content guidance
 
 Aim to use active phrasing for card link text. This means starting the link text with a verb. For example: "Request repeat prescriptions" and "Check for available GP appointments". This follows content guidance on links and helps users to understand the action they can take.

--- a/docs/examples/cards/card-link-secondary-stacked.njk
+++ b/docs/examples/cards/card-link-secondary-stacked.njk
@@ -1,0 +1,47 @@
+---
+layout: layouts/example.njk
+title: Card link secondary stacked
+figmaLink: ""
+vueLink: ""
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCardGroup %}
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+{% from "nhsapp/styles/section-heading/macro.njk" import nhsappSectionHeading %}
+
+{{ nhsappSectionHeading({
+  headingText: "Settings"
+}) }}
+
+{{ nhsappCardGroup({
+  stacked: true,
+  cards: [
+    {
+      title: 'Login and security',
+      href: '#'
+    },
+    {
+      title: 'Face ID',
+      href: '#'
+    }
+  ]
+}) }}
+
+{{ nhsappSectionHeading({
+  headingText: "About the NHS App"
+}) }}
+
+{{ nhsappCardGroup({
+  stacked: true,
+  classes: 'nhsapp-cards--secondary',
+  cards: [
+    {
+      title: 'Privacy and legal policies',
+      href: '#'
+    },
+    {
+      title: 'Join our user research panel',
+      href: '#'
+    }
+  ]
+}) }}

--- a/docs/examples/cards/card-link-secondary.njk
+++ b/docs/examples/cards/card-link-secondary.njk
@@ -1,0 +1,14 @@
+---
+layout: layouts/example.njk
+title: Card link secondary
+figmaLink: ""
+vueLink: ""
+---
+
+{% from "nhsapp/components/card/macro.njk" import nhsappCard %}
+
+{{ nhsappCard({
+  title: 'Find NHS services near you',
+  href: '#',
+  classes: 'nhsapp-card--secondary'
+}) }}

--- a/docs/examples/problem-with-service/example.njk
+++ b/docs/examples/problem-with-service/example.njk
@@ -21,7 +21,8 @@ vueLink:
 
     {{ nhsappCard({
       title: 'Find NHS services near you',
-      href: '#'
+      href: '#',
+      classes: 'nhsapp-card--secondary'
     }) }}
 
   </div>

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -137,6 +137,12 @@ $card-border-hover-color: $color_nhsuk-grey-3;
   }
 }
 
+// secondary card
+.nhsapp-cards--secondary .nhsapp-card,
+.nhsapp-card--secondary {
+  background: transparent;
+}
+
 // combination styles for cards and headings together
 .nhsapp-cards + .nhsapp-section-heading,
 .nhsapp-card + .nhsapp-section-heading,


### PR DESCRIPTION
## Description

Add secondary card link guidance and examples.

- https://github.com/nhsuk/nhsapp-frontend/issues/265

## Note

The visual design of the secondary card link will be reviewed as a part of the future [card link improvements](https://github.com/nhsuk/nhsapp-frontend/issues/270).


