### PR TITLE
Restructure 'Get started' side nav + update page names

### DIFF
--- a/docs/_includes/layouts/community.njk
+++ b/docs/_includes/layouts/community.njk
@@ -31,13 +31,13 @@
         heading: {
           text: 'Contributing'
         },
-        items: collections.contribution | sort(attribute="data.title")
+        items: collections.contribution | sort(attribute="data.order")
       },
       {
         heading: {
           text: 'Support'
         },
-        items: collections.community | sort(attribute="data.title")
+        items: collections.community | sort(attribute="data.order")
       }
     ]
   }) }}

--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -31,13 +31,13 @@
         heading: {
           text: 'Prototyping'
         },
-        items: collections.prototyping
+        items: collections.prototyping | sort(attribute="data.order")
       },
       {
         heading: {
           text: 'Production'
         },
-        items: collections.production
+        items: collections.production | sort(attribute="data.order")
       }
     ]
   }) }}

--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -29,17 +29,25 @@
     sections: [
       {
         heading: {
-          text: 'How we work'
+          text: 'Prototyping'
         },
-        items: collections.getStarted
+        items: collections.prototyping
+      },
+      {
+        heading: {
+          text: 'Production'
+        },
+        items: collections.production
       }
     ]
   }) }}
 {% endset %}
 
 {% block main %}
-  {% if tags and "getStarted" in tags %}
-    <span class="nhsuk-caption-xl">How we work</span>
+  {% if tags and "prototyping" in tags %}
+    <span class="nhsuk-caption-xl">Prototyping</span>
+  {% elif tags and "production" in tags %}
+    <span class="nhsuk-caption-xl">Production</span>
   {% endif %}
   <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
     {{ title }}

--- a/docs/community/help-and-feedback.md
+++ b/docs/community/help-and-feedback.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/community.njk
 title: Help and feedback
+order: 1
 description: The NHS App design system team provides support for users of the NHS App design resources. Contact us to ask for help or to provide feedback.
 tags:
   - community

--- a/docs/community/share-findings.md
+++ b/docs/community/share-findings.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/community.njk
 title: Share your findings
+order: 2
 description: We want to hear how users experience components and patterns in your service. It helps us improve the design system. 
 tags:
   - contribution

--- a/docs/community/suggest-a-change.md
+++ b/docs/community/suggest-a-change.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/community.njk
 title: Suggest a change
+order: 1
 description: You may have questions about our current components and patterns guidance, or changes you want to suggest. There might be something you feel we haven’t covered, or a different approach you’ve noticed another organisation taking, for example. 
 tags:
   - contribution

--- a/docs/get-started/github-and-heroku.md
+++ b/docs/get-started/github-and-heroku.md
@@ -1,15 +1,11 @@
 ---
 layout: layouts/get-started.njk
-title: GitHub and Heroku
+title: Storing and sharing prototypes
 tags:
-  - getStarted
+  - prototyping
 ---
 
 You can use GitHub to store your prototype securely and Heroku to run it for user testing.
-
-## Setting up Git
-
-You first need to follow the NHS prototype guidance on [setting up Git](https://prototype-kit.service-manual.nhs.uk/how-tos/git).
 
 ## Storing your code in GitHub
 

--- a/docs/get-started/github-and-heroku.md
+++ b/docs/get-started/github-and-heroku.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/get-started.njk
 title: Storing and sharing prototypes
+order: 2
 tags:
   - prototyping
 ---

--- a/docs/get-started/nhsapp-frontend.md
+++ b/docs/get-started/nhsapp-frontend.md
@@ -1,11 +1,11 @@
 ---
 layout: layouts/get-started.njk
-title: Production
+title: NHS App frontend
 tags:
-  - getStarted
+  - production
 ---
 
-This guide explains how to set up your project so you can start using the styles and coded examples in the NHS App design system in production.
+This guide explains how to set up the [NHS App frontend](https://github.com/nhsuk/nhsapp-frontend) in production.
 
 ## Before you start
 

--- a/docs/get-started/nhsapp-prototype.md
+++ b/docs/get-started/nhsapp-prototype.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/get-started.njk
 title: NHS App prototype
+order: 1
 tags:
   - prototyping
 ---

--- a/docs/get-started/nhsapp-prototype.md
+++ b/docs/get-started/nhsapp-prototype.md
@@ -1,11 +1,11 @@
 ---
 layout: layouts/get-started.njk
-title: Prototyping
+title: NHS App prototype
 tags:
-  - getStarted
+  - prototyping
 ---
 
-This guide explains how to use the NHS App prototype. You can use it alongside the NHS App design system to make interactive prototypes that look like real NHS App pages.
+This guide explains how to use the [NHS App prototype](https://github.com/nhsuk/nhsapp-prototype). You can use it alongside the NHS App design system to make interactive prototypes that look like real NHS App pages.
 
 Anyone can use the prototype to:
 


### PR DESCRIPTION
## 'Get started` side navigation changes

Changed side nav headings:
- changed side nav heading from `How we work` to `Prototyping` and `Production`

Changed page names:
- `Prototyping` to `NHS App prototype`
- `GitHub and Heroku` to `Storing and sharing prototypes`
- `Production` to `NHS App frontend`

Also, added a custom `order` front matter property so we can adjust the ordering of the pages in the side nav.

| Before | After |
| -------|-------|
| <img width="218" alt="Screenshot 2025-03-18 at 13 55 23" src="https://github.com/user-attachments/assets/b1662b37-556d-4a6b-acd0-38bc9553cfa5" /> | <img width="244" alt="Screenshot 2025-03-18 at 13 55 10" src="https://github.com/user-attachments/assets/6ca8b875-f1b6-45b5-a317-09d5d38ee614" /> |
