### PR TITLE
Update Figma links

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -1,6 +1,6 @@
 <div class="app-example">
   <span class="app-example__new-window">
-    <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new window</a>
+    <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new tab</a>
   </span>
   {%- if mobile == true %}
   <div class="app-iframe__container">
@@ -74,7 +74,7 @@
 
   To use the component in your design, add the NHS App Figma library to your working files, and navigate using the components tab.
 
-  [View component in Figma]({{ figmaLink }})
+  <a href="{{ figmaLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View component in Figma (opens in a new tab)</a>
 </div>
   {% endif -%}
 
@@ -83,7 +83,7 @@
 
   To use the component in your Vue application, install the NHS App Vue Component Library and import the component.
 
-  [View component in Vue]({{ vueLink }})
+  <a href="{{ vueLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View component in Vue (opens in a new tab)</a>
 </div>
   {% endif -%}
 </div>

--- a/docs/_includes/layouts/example.njk
+++ b/docs/_includes/layouts/example.njk
@@ -1,5 +1,7 @@
 {% extends "./base.njk" %}
 
+{% set htmlClasses = "app-html-background-color-grey-5" %}
+
 {% block skiplink %}{% endblock %}
 {% block header %}{% endblock %}
 {% block footer %}{% endblock %}

--- a/docs/components/icons.md
+++ b/docs/components/icons.md
@@ -31,7 +31,7 @@ We use scalable vector graphics (SVG) files for icons. They can be used with or 
 
 {% include "layouts/icons-example.njk" %}
 
-You can find the [icons in Figma](https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=5546-26410&t=QxURQEIfOYBfjOr8-1).
+<p>You can find the <a href="https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=9994-823&p=f&t=VHQbQWtP3hvHke31-0" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">icons in Figma (opens in a new tab)</a>
 
 ## Accessibility
 

--- a/docs/examples/badges/badge-large-9.njk
+++ b/docs/examples/badges/badge-large-9.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Badge Large 9
-figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=128-7303&t=UdzCaY5YPtBypveQ-0"
+figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=9994-822&t=Py584cYX2kHgWqGG-1"
 vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhsbadge-large--docs"
 ---
 

--- a/docs/examples/badges/badge-large.njk
+++ b/docs/examples/badges/badge-large.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Badge Large
-figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=128-7303&t=UdzCaY5YPtBypveQ-0"
+figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=9994-822&t=Py584cYX2kHgWqGG-1"
 vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhsbadge-large--docs"
 ---
 

--- a/docs/examples/badges/badge-small.njk
+++ b/docs/examples/badges/badge-small.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Badge Small
-figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=128-7303&t=UdzCaY5YPtBypveQ-0"
+figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=9994-822&t=Py584cYX2kHgWqGG-1"
 vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhsbadge-small--docs"
 ---
 

--- a/docs/examples/panel/panel-heading-only.njk
+++ b/docs/examples/panel/panel-heading-only.njk
@@ -1,8 +1,8 @@
 ---
 layout: layouts/example.njk
 title: Panel
-figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=10823-3960&t=bu0bKYX8GDeyKVNQ-1"
-vueLink: 
+figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=10823-3960&t=cCcj3EvfNtBU30N4-1"
+vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhspanel--docs"
 ---
 
 {% from "nhsapp/components/panel/macro.njk" import nhsappPanel %}

--- a/docs/examples/panel/panel-with-ref.njk
+++ b/docs/examples/panel/panel-with-ref.njk
@@ -1,8 +1,8 @@
 ---
 layout: layouts/example.njk
 title: Panel
-figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=10823-3960&t=bu0bKYX8GDeyKVNQ-1"
-vueLink: 
+figmaLink: "https://www.figma.com/design/6f2CbcZ7cnpNrtKEcfQp8X/NHS-App-Design-System?node-id=10823-3960&t=cCcj3EvfNtBU30N4-1"
+vueLink: "https://nhsappvuecomponentlibraryv1.nonlive.nhsapp.service.nhs.uk/?path=/docs/components-nhspanel--docs"
 ---
 
 {% from "nhsapp/components/panel/macro.njk" import nhsappPanel %}


### PR DESCRIPTION
## Description

- updated Figma links for components
- added vue link to panel component
- changed Figma and vue links to open in a new tab
- changed wording on examples from "Open this example in new window" to "Open this example in new tab" - following GOV and NHS guidance
- also fixed https://github.com/nhsuk/nhsapp-frontend/issues/281 by changing the HTML colour for examples

<img width="749" alt="Screenshot 2025-03-19 at 11 17 49" src="https://github.com/user-attachments/assets/f8839244-11ee-4a43-abac-cb331cbd5749" />
