### PR TITLE
Update 'How to add NHS App frontend' and 'NHS App frontend' guidance

### DIFF
--- a/docs/get-started/install-nhsapp-frontend.md
+++ b/docs/get-started/install-nhsapp-frontend.md
@@ -1,11 +1,13 @@
 ---
 layout: layouts/get-started.njk
-title: How to add the NHS App frontend to a prototype
+title: Add the NHS App frontend to the NHS prototype kit
 ---
 
-This guide explains how to add the NHS App frontend to the [NHS prototype kit](https://prototype-kit.service-manual.nhs.uk/).
+This guide explains how to add the [NHS App frontend](/get-started/nhsapp-frontend) to the [NHS prototype kit](https://prototype-kit.service-manual.nhs.uk/).
 
-You must follow the [NHS prototype kit setup guide](https://prototype-kit.service-manual.nhs.uk/install) first.
+<div class="nhsuk-inset-text nhsuk-u-margin-top-5">
+  <p>The <a href="/get-started/nhsapp-prototype">NHS App prototype</a> has the NHS App frontend pre-installed.</p>
+</div>
 
 ## Step 1
 
@@ -34,7 +36,7 @@ npm install --save nhsapp-frontend
 In your HTML editor, open
 
 ```sh
-/app/assets/sass/application.scss
+/app/assets/sass/main.scss
 ```
 
 After
@@ -82,9 +84,11 @@ So it looks like this
 ```sh
 const appViews = [
   path.join(__dirname, 'app/views/'),
+  path.join(__dirname, 'lib/example-templates/'),
+  path.join(__dirname, 'lib/prototype-admin/'),
   path.join(__dirname, 'node_modules/nhsuk-frontend/packages/components'),
+  path.join(__dirname, 'node_modules/nhsuk-frontend/packages/macros'),
   path.join(__dirname, 'node_modules/nhsapp-frontend/dist'),
-  path.join(__dirname, 'docs/views/'),
 ];
 ```
 
@@ -108,12 +112,6 @@ and on the next line paste
 app.use('/nhsapp-frontend', express.static(path.join(__dirname, 'node_modules/nhsapp-frontend/dist/nhsapp')));
 ```
 
-Once you have installed NHS App frontend, all NHS App components should work in your prototype.
+## Step 6
 
-You will now have the latest version installed, later you can easily update to the latest NHS App frontend
-
-To use the components, you should:
-
-- find the component in NHS App design components
-- copy the code from the example
-- paste the code into the page in your prototype
+Once you have installed NHS App frontend, all [NHS App components](/components) should work in your prototype.

--- a/docs/get-started/install-nhsapp-frontend.md
+++ b/docs/get-started/install-nhsapp-frontend.md
@@ -3,10 +3,10 @@ layout: layouts/get-started.njk
 title: Add the NHS App frontend to the NHS prototype kit
 ---
 
-This guide explains how to add the [NHS App frontend](/get-started/nhsapp-frontend) to the [NHS prototype kit](https://prototype-kit.service-manual.nhs.uk/).
+This guide shows you how to add the [NHS App frontend](/get-started/nhsapp-frontend) to the [NHS prototype kit](https://prototype-kit.service-manual.nhs.uk/).
 
 <div class="nhsuk-inset-text nhsuk-u-margin-top-5">
-  <p>The <a href="/get-started/nhsapp-prototype">NHS App prototype</a> has the NHS App frontend pre-installed.</p>
+  <p>If you're using the <a href="/get-started/nhsapp-prototype">NHS App prototype</a>, you'll find the NHS App frontend is already included.</p>
 </div>
 
 ## Step 1
@@ -114,4 +114,4 @@ app.use('/nhsapp-frontend', express.static(path.join(__dirname, 'node_modules/nh
 
 ## Step 6
 
-Once you have installed NHS App frontend, all [NHS App components](/components) should work in your prototype.
+After installing the NHS App frontend, all [NHS App components](/components) should work seamlessly in your prototype.

--- a/docs/get-started/nhsapp-frontend.md
+++ b/docs/get-started/nhsapp-frontend.md
@@ -5,23 +5,23 @@ tags:
   - production
 ---
 
-The [NHS App frontend](https://github.com/nhsuk/nhsapp-frontend) is a CSS library built on [NHS.UK frontend](https://github.com/nhsuk/nhsuk-frontend), providing NHS App-specific styles and [components](/components).
+The [NHS App frontend](https://github.com/nhsuk/nhsapp-frontend) is a CSS library built on top of the [NHS.UK frontend](https://github.com/nhsuk/nhsuk-frontend). It provides NHS App-specific styles and [components](/components).
 
 This guide explains how to set up the NHS App frontend in production.
 
 ## Before you start
 
-First you must have followed the [NHS design system production setup guide](https://service-manual.nhs.uk/design-system/production).
+Before you begin, make sure you have followed the [NHS design system production setup guide](https://service-manual.nhs.uk/design-system/production).
 
 ## Include the NHS App frontend in your project
 
-To start using NHS App styles, components and patterns contained here, you’ll need to include NHS App frontend in your project.
+To start using NHS App styles, components, and patterns, you need to add the NHS App frontend to your project.
 
 ### Install using npm
 
-We recommend [installing NHS App frontend using npm](/get-started/installing-with-npm/). Using this option, you will be able to:
+We recommend [installing the NHS App frontend using npm](/get-started/installing-with-npm/). This option lets you:
 
-- selectively include the CSS for individual components
-- build your own styles or components based on the palette or typography and spacing mixins
-- customise the build (for example, overriding colours or enabling global styles)
+- select which component CSS to include
+- build your own styles or components using the palette, typography, and spacing mixins
+- customise the build, such as overriding colours or enabling global styles
 - use the component Nunjucks templates

--- a/docs/get-started/nhsapp-frontend.md
+++ b/docs/get-started/nhsapp-frontend.md
@@ -5,7 +5,9 @@ tags:
   - production
 ---
 
-This guide explains how to set up the [NHS App frontend](https://github.com/nhsuk/nhsapp-frontend) in production.
+The [NHS App frontend](https://github.com/nhsuk/nhsapp-frontend) is a CSS library built on [NHS.UK frontend](https://github.com/nhsuk/nhsuk-frontend), providing NHS App-specific styles and [components](/components).
+
+This guide explains how to set up the NHS App frontend in production.
 
 ## Before you start
 


### PR DESCRIPTION
- https://github.com/nhsuk/nhsapp-frontend/issues/286

## Add the NHS App frontend to the NHS prototype kit guidance

- renamed the page
- added inset text to callout that the NHS App prototype already has the NHS App frontend installed
- fact checked and updated instructions

![image](https://github.com/user-attachments/assets/19f95622-7eb3-4f02-b98d-d60994b1e6e1)

## NHS App frontend guidance

- added a line to explain what the NHS App frontend is
- general content clean-up

![image](https://github.com/user-attachments/assets/6db859e7-2ad6-4034-8e11-a5aeb77c4bd1)

## Next steps
- add link to the 'Add the NHS App frontend to the NHS prototype kit' from the 'NHS App prototype' page as a part of https://github.com/nhsuk/nhsapp-frontend/issues/285
