### PR TITLE
Fix `<p>` spacing within code snippets

### DIFF
--- a/docs/assets/css/_example.scss
+++ b/docs/assets/css/_example.scss
@@ -104,4 +104,7 @@ code:not([class*="language-"]) {
 
 .language-html p {
   font-size: 1em;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
The `<p>` tags within the code snippets were inheriting the NHS.UK frontend spacing.

I've added some code to remove the spacing.

| Before | After |
| -------|-------|
| <img width="738" alt="Screenshot 2025-04-29 at 14 50 20" src="https://github.com/user-attachments/assets/1a02eb35-25eb-4644-8a02-1143a42dcf84" />  | <img width="749" alt="Screenshot 2025-04-29 at 14 50 31" src="https://github.com/user-attachments/assets/e39e0ae5-cf09-42c0-bac3-d859683db5b3" /> |