### PR TITLE
Replace `nhsapp-button--secondary` with `nhsuk-button--secondary` on error page examples

### DIFF
--- a/docs/examples/error-pages/check-internet-connection.njk
+++ b/docs/examples/error-pages/check-internet-connection.njk
@@ -20,7 +20,7 @@ vueLink:
 
     {{ button({
       text: "Try again",
-      classes: "nhsapp-button--secondary nhsapp-button nhsuk-u-margin-top-3"
+      classes: "nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3"
     }) }}
 
   </div>

--- a/docs/examples/error-pages/show-gp-appointments.njk
+++ b/docs/examples/error-pages/show-gp-appointments.njk
@@ -24,7 +24,7 @@ vueLink:
 
     {{ button({
       text: "Try again",
-      classes: "nhsapp-button--secondary nhsapp-button nhsuk-u-margin-top-3"
+      classes: "nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3"
     }) }}
 
     <div class="nhsuk-u-margin-top-1">  

--- a/docs/examples/error-pages/template.njk
+++ b/docs/examples/error-pages/template.njk
@@ -26,7 +26,7 @@ vueLink:
 
     {{ button({
       text: "CTA button",
-      classes: "nhsapp-button--secondary nhsapp-button nhsuk-u-margin-top-3"
+      classes: "nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3"
     }) }}
 
     <h2 class="nhsuk-heading-m">Other options in the NHS App</h2>

--- a/docs/examples/error-pages/update-app.njk
+++ b/docs/examples/error-pages/update-app.njk
@@ -20,7 +20,7 @@ vueLink:
 
     {{ button({
       text: "Update the NHS App",
-      classes: "nhsapp-button--secondary nhsapp-button nhsuk-u-margin-top-3"
+      classes: "nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3"
     }) }}
 
   </div>


### PR DESCRIPTION
We have bumped the nhsuk-frontend version so we are now using the nhsuk secondary buttons.