### PR TITLE
Add automated PR preview deployments

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -146,8 +146,7 @@ export default function (eleventyConfig) {
   eleventyConfig.setLibrary('md', markdownIt({ html: true }).use(anchor))
 
   return {
-    // Add path prefix support for PR previews
-    pathPrefix: process.env.ELEVENTY_PATH_PREFIX || '',
+    // No pathPrefix needed for Netlify - each PR gets its own clean URL
     dir: {
       input: 'docs',
       output: 'dist/docs'

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -146,6 +146,8 @@ export default function (eleventyConfig) {
   eleventyConfig.setLibrary('md', markdownIt({ html: true }).use(anchor))
 
   return {
+    // Add path prefix support for PR previews
+    pathPrefix: process.env.ELEVENTY_PATH_PREFIX || '',
     dir: {
       input: 'docs',
       output: 'dist/docs'

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -146,7 +146,6 @@ export default function (eleventyConfig) {
   eleventyConfig.setLibrary('md', markdownIt({ html: true }).use(anchor))
 
   return {
-    // No pathPrefix needed for Netlify - each PR gets its own clean URL
     dir: {
       input: 'docs',
       output: 'dist/docs'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -40,14 +40,14 @@ jobs:
           ELEVENTY_PATH_PREFIX: /pr-${{ github.event.number }}
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/docs
           destination_dir: pr-${{ github.event.number }}
 
       - name: Comment PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@v3.0
+        uses: nwtgck/actions-netlify@4cbaf4c52b8e0b61c6de74b7d46df0b04ce8a8a6 # v3.0.0
         with:
           publish-dir: './dist/docs'
           production-branch: main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,26 +39,81 @@ jobs:
         env:
           ELEVENTY_PATH_PREFIX: /pr-${{ github.event.number }}
 
+      - name: Debug build output
+        run: |
+          echo "=== Build directory contents ==="
+          ls -la dist/docs/
+          echo ""
+          echo "=== Looking for index.html ==="
+          find dist/docs/ -name "index.html" -type f
+          echo ""
+          echo "=== Sample HTML content (first 20 lines) ==="
+          head -20 dist/docs/index.html || echo "No index.html found"
+          echo ""
+          echo "=== PR number ==="
+          echo "PR number: ${{ github.event.number }}"
+          echo "Destination dir will be: pr-${{ github.event.number }}"
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/docs
           destination_dir: pr-${{ github.event.number }}
+          keep_files: true
+
+      - name: Debug deployment
+        run: |
+          echo "=== Deployment completed ==="
+          echo "Expected URL: https://nhsuk.github.io/nhsapp-frontend/pr-${{ github.event.number }}/"
+          echo "Files should be in gh-pages branch under: pr-${{ github.event.number }}/"
 
       - name: Comment PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = `https://design-system.nhsapp.service.nhs.uk/pr-${prNumber}/`;
+            const previewUrl = `https://nhsuk.github.io/nhsapp-frontend/pr-${prNumber}/`;
+            const commentBody = `🚀 Preview deployed to: ${previewUrl}
 
-            github.rest.issues.createComment({
-              issue_number: prNumber,
+            _Last updated: ${new Date().toLocaleString('en-GB', { 
+              timeZone: 'Europe/London',
+              year: 'numeric',
+              month: 'short', 
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit'
+            })}_`;
+
+            // Find existing preview comment
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🚀 Preview deployed to: ${previewUrl}`
+              issue_number: prNumber,
             });
+
+            const existingComment = comments.find(comment => 
+              comment.user.login === 'github-actions[bot]' && 
+              comment.body.includes('🚀 Preview deployed to:')
+            );
+
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
+              });
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+            }
 
   cleanup:
     if: github.event.action == 'closed'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,6 @@
 # Update your existing .github/workflows/pr.yaml
 name: PR checks
-on: 
+on:
   pull_request:
     types: [opened, synchronize, closed]
 
@@ -26,32 +26,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          
+
       - name: Install dependencies
         run: npm ci
-        
+
       - name: Build site
         run: npm run docs:build
-        
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist/docs
           destination_dir: pr-${{ github.event.number }}
-          
+
       - name: Comment PR
         uses: actions/github-script@v7
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
             const previewUrl = `https://design-system.nhsapp.service.nhs.uk/pr-${prNumber}/`;
-            
+
             github.rest.issues.createComment({
               issue_number: prNumber,
               owner: context.repo.owner,
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-          
+
       - name: Remove preview folder
         run: |
           rm -rf pr-${{ github.event.number }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@4cbaf4c52b8e0b61c6de74b7d46df0b04ce8a8a6 # v3.0.0
+        uses: nwtgck/actions-netlify@4cbaf4c # v3.0.0
         with:
           publish-dir: './dist/docs'
           production-branch: main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, closed]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
@@ -36,44 +36,28 @@ jobs:
 
       - name: Build site
         run: npm run docs:build
-        env:
-          ELEVENTY_PATH_PREFIX: /pr-${{ github.event.number }}
 
-      - name: Debug build output
-        run: |
-          echo "=== Build directory contents ==="
-          ls -la dist/docs/
-          echo ""
-          echo "=== Looking for index.html ==="
-          find dist/docs/ -name "index.html" -type f
-          echo ""
-          echo "=== Sample HTML content (first 20 lines) ==="
-          head -20 dist/docs/index.html || echo "No index.html found"
-          echo ""
-          echo "=== PR number ==="
-          echo "PR number: ${{ github.event.number }}"
-          echo "Destination dir will be: pr-${{ github.event.number }}"
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v3.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist/docs
-          destination_dir: pr-${{ github.event.number }}
-          keep_files: true
-
-      - name: Debug deployment
-        run: |
-          echo "=== Deployment completed ==="
-          echo "Expected URL: https://nhsuk.github.io/nhsapp-frontend/pr-${{ github.event.number }}/"
-          echo "Files should be in gh-pages branch under: pr-${{ github.event.number }}/"
+          publish-dir: './dist/docs'
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: 'Deploy from GitHub Actions'
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        id: netlify
 
       - name: Comment PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = `https://nhsuk.github.io/nhsapp-frontend/pr-${prNumber}/`;
+            const previewUrl = '${{ steps.netlify.outputs.deploy-url }}';
             const commentBody = `🚀 Preview deployed to: ${previewUrl}
 
             _Last updated: ${new Date().toLocaleString('en-GB', { 
@@ -114,21 +98,3 @@ jobs:
                 body: commentBody
               });
             }
-
-  cleanup:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-
-      - name: Remove preview folder
-        run: |
-          rm -rf pr-${{ github.event.number }}
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Remove preview for PR #${{ github.event.number }}" || exit 0
-          git push

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,3 @@
-# Update your existing .github/workflows/pr.yaml
 name: PR checks
 on:
   pull_request:
@@ -37,6 +36,8 @@ jobs:
 
       - name: Build site
         run: npm run docs:build
+        env:
+          ELEVENTY_PATH_PREFIX: /pr-${{ github.event.number }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,16 @@
+# Update your existing .github/workflows/pr.yaml
 name: PR checks
+on: 
+  pull_request:
+    types: [opened, synchronize, closed]
 
-on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   linting:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -12,3 +19,60 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm run lint
+
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build site
+        run: npm run docs:build
+        
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/docs
+          destination_dir: pr-${{ github.event.number }}
+          
+      - name: Comment PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://design-system.nhsapp.service.nhs.uk/pr-${prNumber}/`;
+            
+            github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 Preview deployed to: ${previewUrl}`
+            });
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          
+      - name: Remove preview folder
+        run: |
+          rm -rf pr-${{ github.event.number }}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Remove preview for PR #${{ github.event.number }}" || exit 0
+          git push

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy to Netlify
-        uses: nwtgck/actions-netlify@4cbaf4c # v3.0.0
+        uses: nwtgck/actions-netlify@4cbaf4c08f1a7bfa537d6113472ef4424e4eb654 # v3.0.0
         with:
           publish-dir: './dist/docs'
           production-branch: main


### PR DESCRIPTION
This PR adds automatic preview deployments for all pull requests using Netlify. Each PR now gets its own live preview URL for easier reviewing.

## What happens

- **Open a PR** → Automatic preview deployment with unique URL
- **Preview URL** posted as comment (updates on new commits)  
- **Close PR** → Preview automatically cleaned up

## Example

- **Production:** https://design-system.nhsapp.service.nhs.uk/ (unchanged)
- **PR Preview:** https://deploy-preview-337--[site-name].netlify.app (this PR's preview)

The GitHub Actions bot will post the actual preview link below.

## Related issue

- https://github.com/nhsuk/nhsapp-frontend/issues/54