### PR TITLE
Minor update to 'letting users report a technical problem' guidance

### DIFF
--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -94,7 +94,7 @@ Talk to your service’s clinical lead for advice when you create or update an e
 
 Signpost users to contact the NHS App team if:
 
-- the error is being tracked by the service management team
+- the service management team agree it could be helpful in this scenario
 - it's a technical problem
 
 Use the h2 "If the problem continues" and include an error code.


### PR DESCRIPTION
Small change agreed with Dave Barrett and Robin Barker, as part of a conversation about error handling. It's less a case of designers checking whether service management are already tracking an error, and more about having a conversation with them to see if directing users to the contact form is helpful in a given scenario.