### PR TITLE
Update error page guidance

### DIFF
--- a/docs/examples/error-pages/login.njk
+++ b/docs/examples/error-pages/login.njk
@@ -21,7 +21,7 @@ vueLink:
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
 
-<h2 class="nhsuk-heading-m">For urgent medical advice</h2>
+    <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 
     <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>
 

--- a/docs/examples/error-pages/login.njk
+++ b/docs/examples/error-pages/login.njk
@@ -1,0 +1,33 @@
+---
+layout: layouts/example-full-page-mobile-not-logged-in.njk
+mobile: true
+mobileHeader: blue
+title: Error page - Problem logging in
+figmaLink: 
+vueLink: 
+---
+
+{% from 'button/macro.njk' import button %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <h1 class="nhsuk-u-margin-bottom-5">There is a problem logging in</h1>
+
+    <p>Close the NHS App, reopen it and try logging in again.</p>
+
+    {{ button({
+      text: 'Close the NHS App',
+      classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
+    }) }}
+
+<h2 class="nhsuk-heading-m">For urgent medical advice</h2>
+
+    <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>
+
+    <h2 class="nhsuk-heading-m">For technical support</h2>
+
+    <p>Make a note of the error code <strong>3s4353</strong> and then <a href="https://www.nhs.uk/contact-us/nhs-app-contact-us/">contact the NHS App team</a>.</p>
+
+  </div>
+</div>

--- a/docs/examples/error-pages/referrals.njk
+++ b/docs/examples/error-pages/referrals.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example-full-page-mobile.njk
 mobile: true
-title: Error page - Show GP appointments
+title: Error page - Referrals
 hub: Your health
 figmaLink: 
 vueLink: 
@@ -12,7 +12,7 @@ vueLink:
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
-    <h1 class="nhsuk-u-margin-bottom-5">There is a problem with showing your GP appointments</h1>
+    <h1 class="nhsuk-u-margin-bottom-5">There is a problem showing your referrals</h1>
 
     <p>This may be a temporary problem.</p>
 
@@ -21,8 +21,8 @@ vueLink:
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
 
-    <p>Contact your GP surgery directly if you need to book or change an appointment now.</p>
-    
+    <p>If the problem continues, contact your healthcare team directly.</p>
+
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 
     <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>

--- a/docs/examples/error-pages/referrals.njk
+++ b/docs/examples/error-pages/referrals.njk
@@ -16,7 +16,7 @@ vueLink:
 
     <p>This may be a temporary problem.</p>
 
-        {{ button({
+    {{ button({
       text: 'Try again',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}

--- a/docs/examples/error-pages/show-gp-appointments-olc.njk
+++ b/docs/examples/error-pages/show-gp-appointments-olc.njk
@@ -12,7 +12,7 @@ vueLink:
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
-    <h1 class="nhsuk-u-margin-bottom-5">There is a problem with showing your GP appointments</h1>
+    <h1 class="nhsuk-u-margin-bottom-5">There is a problem showing your GP appointments</h1>
 
     <p>This may be a temporary problem.</p>
 
@@ -22,7 +22,16 @@ vueLink:
     }) }}
 
     <p>Contact your GP surgery directly if you need to book or change an appointment now.</p>
-    
+
+{% from 'nhsapp/components/card/macro.njk' import nhsappCard %}
+
+{{ nhsappCard({
+  title: 'Ask about a health problem',
+  href: '#',
+  description: 'Provided using eConsult',
+  classes: 'nhsapp-card--secondary'
+}) }}
+
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 
     <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>

--- a/docs/examples/error-pages/show-gp-appointments-olc.njk
+++ b/docs/examples/error-pages/show-gp-appointments-olc.njk
@@ -16,21 +16,21 @@ vueLink:
 
     <p>This may be a temporary problem.</p>
 
-        {{ button({
+    {{ button({
       text: 'Try again',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
 
     <p>Contact your GP surgery directly if you need to book or change an appointment now.</p>
 
-{% from 'nhsapp/components/card/macro.njk' import nhsappCard %}
+    {% from 'nhsapp/components/card/macro.njk' import nhsappCard %}
 
-{{ nhsappCard({
-  title: 'Ask about a health problem',
-  href: '#',
-  description: 'Provided using eConsult',
-  classes: 'nhsapp-card--secondary'
-}) }}
+    {{ nhsappCard({
+      title: 'Ask about a health problem',
+      href: '#',
+      description: 'Provided using eConsult',
+      classes: 'nhsapp-card--secondary'
+    }) }}
 
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 

--- a/docs/examples/error-pages/test-results.njk
+++ b/docs/examples/error-pages/test-results.njk
@@ -16,7 +16,7 @@ vueLink:
 
     <p>Try logging out of the NHS App and logging in again.</p>
 
-        {{ button({
+    {{ button({
       text: 'Log out',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}

--- a/docs/examples/error-pages/test-results.njk
+++ b/docs/examples/error-pages/test-results.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example-full-page-mobile.njk
 mobile: true
-title: Error page - Show GP appointments
+title: Error page - Test results
 hub: Your health
 figmaLink: 
 vueLink: 
@@ -12,16 +12,14 @@ vueLink:
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
-    <h1 class="nhsuk-u-margin-bottom-5">There is a problem with showing your GP appointments</h1>
+    <h1 class="nhsuk-u-margin-bottom-5">There is a problem showing your test results</h1>
 
-    <p>This may be a temporary problem.</p>
+    <p>Try logging out of the NHS App and logging in again.</p>
 
         {{ button({
-      text: 'Try again',
+      text: 'Log out',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
-
-    <p>Contact your GP surgery directly if you need to book or change an appointment now.</p>
     
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 
@@ -29,7 +27,7 @@ vueLink:
 
     <h2 class="nhsuk-heading-m">For technical support</h2>
 
-    <p>Make a note of the error code <strong>4k4353</strong> and then <a href="https://www.nhs.uk/contact-us/nhs-app-contact-us/">contact the NHS App team</a>.</p>
+    <p>Make a note of the error code <strong>ze4353</strong> and then <a href="https://www.nhs.uk/contact-us/nhs-app-contact-us/">contact the NHS App team</a>.</p>
 
   </div>
 </div>

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -32,11 +32,8 @@
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
             <h2>What's new</h2>
-            <h3 class="nhsuk-heading-s">27 June 2025: Error page guidance</h3>
-            <p>We added a <a href="/patterns/">patterns</a> page with <a href="/patterns/error-page">error page guidance</a>.</p>
-            <h3 class="nhsuk-heading-s">17 June 2025: We released NHS App frontend 4.0.0.</h3>
-            <p>This release updates our dependency to nhsuk-frontend v9.6.2 and deprecates duplicate components that are now available in the main NHS.UK frontend library.</p>
-            <p>Read the <a href="https://github.com/nhsuk/nhsapp-frontend/releases" class="nhsuk-link--no-visited-state">full release notes</a> to see what's changed and how to migrate deprecated components.</p>
+            <h3 class="nhsuk-heading-s">23 December 2025: We've updated our component library</h3>
+            <p>This release brings all the changes from nhsuk-frontend v10 and nhsapp-frontend v5 into our component library, including new, rounder designs for <a href="https://design-system.nhsapp.service.nhs.uk/components/buttons/">buttons</a> and <a href="https://design-system.nhsapp.service.nhs.uk/components/card-links/">cards</a>. Read the <a href="https://github.com/nhsuk/nhsapp-frontend/releases" class="nhsuk-link--no-visited-state">full release notes</a>.</p>
           </div>
         </div>
       </div>

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -32,8 +32,11 @@
         <div class="nhsuk-grid-row">
           <div class="nhsuk-grid-column-two-thirds">
             <h2>What's new</h2>
-            <h3 class="nhsuk-heading-s">23 December 2025: We've updated our component library</h3>
-            <p>This release brings all the changes from nhsuk-frontend v10 and nhsapp-frontend v5 into our component library, including new, rounder designs for <a href="https://design-system.nhsapp.service.nhs.uk/components/buttons/">buttons</a> and <a href="https://design-system.nhsapp.service.nhs.uk/components/card-links/">cards</a>. Read the <a href="https://github.com/nhsuk/nhsapp-frontend/releases" class="nhsuk-link--no-visited-state">full release notes</a>.</p>
+            <h3 class="nhsuk-heading-s">27 June 2025: Error page guidance</h3>
+            <p>We added a <a href="/patterns/">patterns</a> page with <a href="/patterns/error-page">error page guidance</a>.</p>
+            <h3 class="nhsuk-heading-s">17 June 2025: We released NHS App frontend 4.0.0.</h3>
+            <p>This release updates our dependency to nhsuk-frontend v9.6.2 and deprecates duplicate components that are now available in the main NHS.UK frontend library.</p>
+            <p>Read the <a href="https://github.com/nhsuk/nhsapp-frontend/releases" class="nhsuk-link--no-visited-state">full release notes</a> to see what's changed and how to migrate deprecated components.</p>
           </div>
         </div>
       </div>

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -13,8 +13,12 @@ tags:
 
 Use an error page when:
 
-- there is an unexpected technical problem
+- there is an unexpected problem
 - users cannot access the service
+
+Log all errors and fix them as quickly as possible. 
+
+Consider closing the service an using a [service unavailable page](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) if the problem happens persistently and for a long time. 
 
 ## When not to use
 
@@ -28,18 +32,11 @@ Do not use this pattern if:
 
 ### 1. Main heading
 
-Use the main heading (H1) to explain what is wrong. Start with: "There is a problem" followed by a short description.
-
-If the cause of the error is unknown or complicated, you can use: "There is a technical problem".
+Start the main heading with "There is a problem" followed by a description of the service or feature that has gone wrong.
 
 ### 2. Main body text
 
-You can use the main body text to:
-
-- give more details
-- set the context for the action that follows
-
-Keep the text concise.
+Use the main body text to tell users how to resolve the problem, or to give more details. Keep the text concise.
 
 ### 3. Button
 
@@ -48,38 +45,36 @@ Use a secondary button for an action that may help to resolve the problem. This 
 - "Try again" (refreshing the page)
 - "Log out"
 
-Work closely with developers and the Service Management Team to understand what users can do in the scenario.
-
-Place buttons straight after the body text that sets the context for the action.
+The button should come straight after the related body text.
 
 {% example "error-pages/referrals.njk" %}
 
 ### 4. Secondary body text
 
-If needed, you can use the space beneath the button to:
+Use the space beneath the button to:
 
 - let users know about a different way to access the service
 - give links to another relevant service
+
+Always tell users how to complete their task through a different channel. The NHS App is a healthcare service. Errors can delay access to clinic care, and users may be experiencing urgent health needs.
 
 For links to other NHS App services, use a secondary card link.
 
 {% example "error-pages/show-gp-appointments-olc.njk" %}
 
-### 5. Signposting to medical help
+### 5. Signposting to urgent medical help
 
-Always include signposting to medical help on error pages.
+Always include signposting to urgent medical help on error pages.
 
-Use the heading: "For urgent medical advice" followed by the text: "Use [111 online](https://111.nhs.uk/) or [call 111](https://111.nhs.uk/)."
+Use the heading "For urgent medical advice" followed by the text "Use [111 online](https://111.nhs.uk/) or [call 111](https://111.nhs.uk/)."
 
 ### 6. Signposting to technical support
 
-If the Service Management Team agree they can help users in the scenario, use the heading: "For technical help" followed by the text: "Make a note of the error code **xxxxx** and then contact the [NHS App team](https://www.nhs.uk/contact-us/nhs-app-contact-us/)". Insert a relevant error code where the bold text is.
-
-It can help users if they include the error code in the contact form. It helps the Service Management Team to provide them with the relevant help information more quickly.
+If the Service Management Team can help users in the scenario, use the heading "For technical help" followed by the text "Make a note of the error code **xxxxx** and then [contact the NHS App team](https://www.nhs.uk/contact-us/nhs-app-contact-us/)". Insert a relevant error code where the bold text is.
 
 ## If a user is logged out
 
-Logged-out errors do not display the app header or footer.
+Do not include the app header or footer if the user is logged out.
 
 {% example "error-pages/login.njk" %}
 
@@ -110,8 +105,9 @@ We should account for these challenges in our designs and continue to research a
 We want to learn more about:
 
 - "try again" buttons on errors, and how we can best help users when these fail to solve the problem
-- how we can avoid users needing to manually input error codes, for example by pre-populating these codes on our contact form
 - how this guidance could evolve into separate pages covering specific errors
+
+We are in the process of updating the NHS App contact form. This update will remove the need for users to note down error codes on error pages, as these codes will be pre-populated into the form.
 
 ## Design history
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -1,113 +1,99 @@
 ---
 layout: layouts/pattern.njk
 title: Error pages
-description: Use error pages to tell users there is a problem. Explain what has happened and what they can do next.
+description: Use error pages to tell users there is an unexpected problem. Explain what has happened and what they can do next.
 backlogID: 119
 tags:
   - page
 ---
 
-{% example "error-pages/show-gp-appointments.njk" %}
+{% example "error-pages/test-results.njk" %}
 
 ## When to use
 
 Use an error page when:
 
-- something has gone wrong
-- users cannot continue to the next page
+- there is an unexpected technical problem
+- users cannot access the service
 
 ## When not to use
 
-Do not use this type of error page if:
+Do not use this pattern if:
 
-- you can adapt GOV.UK patterns for [page not found](https://design-system.service.gov.uk/patterns/page-not-found-pages/), [service unavailable](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) or [there is a problem with the service](https://design-system.service.gov.uk/patterns/problem-with-the-service-pages/)
-- a user makes a mistake completing a form – instead follow the NHS service manual guidance for [error messages](https://service-manual.nhs.uk/design-system/components/error-message) and [errors summaries](https://service-manual.nhs.uk/design-system/components/error-summary)
+- you can adapt GOV.UK patterns for [page not found](https://design-system.service.gov.uk/patterns/page-not-found-pages/) or [service unavailable](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) 
+- a user makes a mistake completing a form – instead, follow the NHS service manual guidance for [error messages](https://service-manual.nhs.uk/design-system/components/error-message) and [errors summaries](https://service-manual.nhs.uk/design-system/components/error-summary)
+- a user cannot continue for an expected reason, for example because they are not eligble – instead, check our GitHub discussion on <a href="https://github.com/nhsuk/nhsapp-frontend/issues/411">unhappy path pages</a>
 
-## How to use
+## How to structure an error page
 
-The content for each type of error will vary depending on the circumstances.
+### 1. Main heading
 
-The page should:
+Use the main heading (H1) to explain what is wrong. Start with: "There is a problem" followed by a short description.
 
-- be clear and concise
-- summarise the problem, or give an instruction, in the main heading (h1)
-- tell the user how to access the service another way, or use an alternative
-- tell the user if there's something they can do to fix the problem
+If the cause of the error is unknown or complicated, you can use: "There is a technical problem".
 
-This page should not:
+### 2. Main body text
+
+You can use the main body text to: 
+
+- give more details 
+- set the context for the action that follows 
+
+Keep the text concise. 
+
+### 3. Button
+
+Use a secondary button for an action that may help to resolve the problem. This could include:
+
+- "Try again" (refreshing the page)
+- "Log out"
+
+Work closely with developers and the Service Management Team to understand what users can do in the scenario.
+
+Place buttons straight after the body text that sets the context for the action.
+
+{% example "error-pages/referrals.njk" %}
+
+### 4. Secondary body text
+
+If needed, you can use the space beneath the button to:
+
+- let users know about a different way to access the service
+- give links to another relevant service
+
+For links to other NHS App services, use a secondary card link.
+
+{% example "error-pages/show-gp-appointments-olc.njk" %}
+
+### 5. Signposting to medical help
+
+Always include signposting to medical help on error pages.
+
+Use the heading: "For urgent medical advice" followed by the text: "Use [111 online](https://111.nhs.uk/) or [call 111](https://111.nhs.uk/)."
+
+### 6. Signposting to technical support
+
+If the Service Management Team agree they can help users in the scenario, use the heading: "For technical help" followed by the text: "Make a note of the error code **xxxxx** and then contact the [NHS App team](https://www.nhs.uk/contact-us/nhs-app-contact-us/)". Insert a relevant error code where the bold text is.
+
+It can help users if they include the error code in the contact form. It helps the Service Management Team to provide them with the relevant help information more quickly.
+
+## If a user is logged out
+
+Logged-out errors do not display the app header or footer.
+
+{% example "error-pages/login.njk" %}
+
+## How not to use
+
+The page should not:
 
 - blame the user
-- use breadcrumbs or a standard back link at the top
+- include breadcrumbs or a back link at the top
 - display vague terms or jargon like "500", "504", "bad request" or "we are experiencing technical difficulties"
 - use red text to warn people
 - use exclamation marks or informal language like "oops"
 
-You should try to get feedback from users on error pages. It's likely they will have important insights about common issues on your service that need to be fixed.
-
-### Writing headings
-
-Use the main heading to clearly explain the problem or a solution.
-
-Some error headings work better as instructions and some work better as descriptions.
-
-Headings should be grammatically correct. Avoid abbreviated headings like "Prescriptions not available" as they can make it harder for users to understand what's caused the problem.
-
-#### Instructive headings
-
-If there’s a direct action the user can take to fix the problem, use the main heading to tell them this. Start the main heading with the verb that indicates the action they need to take. For example:
-
-- "Update the NHS App to continue"
-- "Check you’re registered with a GP in England"
-
-{% example "error-pages/update-app.njk" %}
-
-#### Descriptive headings
-
-Descriptive headings often work better for a problem that lies with the NHS App. Starting the main heading with "we" can help make this clear. For example:
-
-- "We could not log you in"
-- "We could not show your confirmed prescriptions"
-
-{% example "error-pages/confirmed-prescriptions.njk" %}
-
-### Using calls to action and links
-
-The components we use for calls to action and links depend on the context.
-
-Use a:
-
-- [secondary button](/components/buttons/#secondary-button) to give a call to action that may help fix the problem
-- [secondary card link](/components/card-links/#secondary-card-links) under a h2 of "Other options in the NHS App" for links to services in the NHS App
-- [text link](https://service-manual.nhs.uk/design-system/styles/typography#links) to navigate users back to a specific area of the app, for example, "Go to appointments"
-
 Avoid giving users too many different links to choose from as a next step. This increases cognitive load, and is problematic for users experiencing high levels of stress or anxiety.
-
-### Helping users get care another way
-
-Always tell users how they can complete their task through a different channel.
-
-Remember that the NHS App is a healthcare service. Errors can delay access to clinical care, and users may be experiencing urgent health needs.
-
-Talk to your service’s clinical lead for advice when you create or update an error page.
-
-### Letting users report a technical problem
-
-Signpost users to contact the NHS App team if:
-
-- the service management team agree it could be helpful in this scenario
-- it's a technical problem
-
-Use the h2 "If the problem continues" and include an error code.
-
-Speak to the service management team for advice when you create or update an error page.
-
-{% example "error-pages/manage-services.njk" %}
-
-### When a user is not logged in
-
-The top and bottom navigation are not visible because the user is not logged in.
-
-{% example "error-pages/check-internet-connection.njk" %}
 
 ## Research
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -20,7 +20,7 @@ Use an error page when:
 
 Do not use this pattern if:
 
-- you can adapt GOV.UK patterns for [page not found](https://design-system.service.gov.uk/patterns/page-not-found-pages/) or [service unavailable](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) 
+- you can adapt GOV.UK patterns for [page not found](https://design-system.service.gov.uk/patterns/page-not-found-pages/) or [service unavailable](https://design-system.service.gov.uk/patterns/service-unavailable-pages/)
 - a user makes a mistake completing a form – instead, follow the NHS service manual guidance for [error messages](https://service-manual.nhs.uk/design-system/components/error-message) and [errors summaries](https://service-manual.nhs.uk/design-system/components/error-summary)
 - a user cannot continue for an expected reason, for example because they are not eligible – instead, check our GitHub discussion on <a href="https://github.com/nhsuk/nhsapp-frontend/issues/411">unhappy path pages</a>
 
@@ -34,12 +34,12 @@ If the cause of the error is unknown or complicated, you can use: "There is a te
 
 ### 2. Main body text
 
-You can use the main body text to: 
+You can use the main body text to:
 
-- give more details 
-- set the context for the action that follows 
+- give more details
+- set the context for the action that follows
 
-Keep the text concise. 
+Keep the text concise.
 
 ### 3. Button
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -16,9 +16,9 @@ Use an error page when:
 - there is an unexpected problem
 - users cannot access the service
 
-Log all errors and fix them as quickly as possible. 
+Log all errors and fix them as quickly as possible.
 
-Consider closing the service an using a [service unavailable page](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) if the problem happens persistently and for a long time. 
+Consider closing the service an using a [service unavailable page](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) if the problem happens persistently and for a long time.
 
 ## When not to use
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -22,7 +22,7 @@ Do not use this pattern if:
 
 - you can adapt GOV.UK patterns for [page not found](https://design-system.service.gov.uk/patterns/page-not-found-pages/) or [service unavailable](https://design-system.service.gov.uk/patterns/service-unavailable-pages/) 
 - a user makes a mistake completing a form – instead, follow the NHS service manual guidance for [error messages](https://service-manual.nhs.uk/design-system/components/error-message) and [errors summaries](https://service-manual.nhs.uk/design-system/components/error-summary)
-- a user cannot continue for an expected reason, for example because they are not eligble – instead, check our GitHub discussion on <a href="https://github.com/nhsuk/nhsapp-frontend/issues/411">unhappy path pages</a>
+- a user cannot continue for an expected reason, for example because they are not eligible – instead, check our GitHub discussion on <a href="https://github.com/nhsuk/nhsapp-frontend/issues/411">unhappy path pages</a>
 
 ## How to structure an error page
 


### PR DESCRIPTION
This update to our error page guidance and examples reflects recent design work and user research from the following teams:

- GP Services
- Secondary Care Services
- Navigation and Onboarding

It gives greater clarity on the difference between:

- error pages
- unhappy path pages

It provides developers with a more structured page template that we can standardise across the app.