### PR TITLE
Update URL for app prototype on GitHub

### DIFF
--- a/docs/get-started/nhsapp-prototype/index.md
+++ b/docs/get-started/nhsapp-prototype/index.md
@@ -22,7 +22,7 @@ You can also [read a blog about why prototyping in code is important](https://di
 
 We welcome feedback and suggestions to help improve the NHS App prototype.
 
-If you have any ideas, feature requests, or issues to report, please [submit an issue on GitHub](https://github.com/nhsuk/nhsapp-prototype/issues).
+If you have any ideas, feature requests, or issues to report, please [submit an issue on GitHub](https://github.com/NHSDigital/nhsapp-prototype/issues).
 
 <hr class="nhsuk-section-break nhsuk-section-break--xl nhsuk-section-break--visible app-section-break--width-4">
 

--- a/docs/get-started/nhsapp-prototype/setup.md
+++ b/docs/get-started/nhsapp-prototype/setup.md
@@ -20,9 +20,9 @@ If you're not sure whether the tools are installed â€“ or how to install them â€
 
 ## Download the NHS App prototype
 
-The simplest way to get a copy is to [download it as a zip](https://github.com/nhsuk/nhsapp-prototype/archive/refs/heads/main.zip).
+The simplest way to get a copy is to [download it as a zip](https://github.com/NHSDigital/nhsapp-prototype/archive/refs/heads/main.zip).
 
-You can also clone or download a copy from [GitHub](https://github.com/nhsuk/nhsapp-prototype).
+You can also clone or download a copy from [GitHub](https://github.com/NHSDigital/nhsapp-prototype).
 
 <div class="nhsuk-inset-text nhsuk-u-margin-top-0">
   <p>You can download a new copy for each project and <a href="/get-started/nhsapp-prototype/github">store your code on GitHub</a>.</p>


### PR DESCRIPTION
This has moved from the `nhsuk` github org to `NHSDigital`.

(The old URL redirects, so this just saves the redirect.)