### PR TITLE
Update links to NHS prototype kit site

### DIFF
--- a/docs/get-started/nhsapp-prototype/github.md
+++ b/docs/get-started/nhsapp-prototype/github.md
@@ -14,7 +14,7 @@ Store your prototype as a repository in the GitHub NHS Digital organisation acco
 3. Select **New** to create a repository.
 4. Name your prototype to avoid confusion with production services. Use the format `nhsapp-prototype-[project-name]`, such as `nhsapp-prototype-prescriptions`.
 5. Select **Internal** and **Create repository**.
-6. Upload your prototype to GitHub. You can follow the NHS prototype kit guidance on how to [store code online with GitHub and GitHub Desktop](https://prototype-kit.service-manual.nhs.uk/how-tos/github/index).
+6. Upload your prototype to GitHub. You can follow the NHS prototype kit guidance on how to [store code online with GitHub and GitHub Desktop](https://prototype-kit.service-manual.nhs.uk/guides/github/).
 
 <hr class="nhsuk-section-break nhsuk-section-break--xl nhsuk-section-break--visible app-section-break--width-4">
 

--- a/docs/get-started/nhsapp-prototype/heroku.md
+++ b/docs/get-started/nhsapp-prototype/heroku.md
@@ -18,7 +18,7 @@ You can host your NHS App prototype using Heroku and connect it directly to your
 7. Choose a branch (usually `main`).
 8. Enable **Automatic deploys** to publish changes every time you push to GitHub.
 9. Select **Deploy Branch**.
-10. In **Settings > Config Vars > Reveal Config Vars** you need to set a password - [see NHS prototype kit guidance for setting a password](https://prototype-kit.service-manual.nhs.uk/how-tos/publish-your-prototype-online).
+10. In **Settings > Config Vars > Reveal Config Vars** you need to set a password - [see NHS prototype kit guidance for setting a password](https://prototype-kit.service-manual.nhs.uk/guides/publish-your-prototype-online/).
 11. Select **Open app** to view your prototype.
 
 <hr class="nhsuk-section-break nhsuk-section-break--xl nhsuk-section-break--visible app-section-break--width-4">

--- a/docs/get-started/nhsapp-prototype/how-to-use.md
+++ b/docs/get-started/nhsapp-prototype/how-to-use.md
@@ -20,11 +20,11 @@ If you're new to HTML and CSS, you can get started with online tutorials from:
 
 ## NHS prototype kit guides
 
-The [NHS prototype kit guides](https://prototype-kit.service-manual.nhs.uk/how-tos) provide step-by-step instructions – from creating a simple page to building complex user journeys.
+The [NHS prototype kit guides](https://prototype-kit.service-manual.nhs.uk/guides) provide step-by-step instructions – from creating a simple page to building complex user journeys.
 
 ### Build a basic prototype tutorial
 
-We recommend following the [build a basic prototype tutorial](https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/index) to familiarise yourself with prototyping.
+We recommend following the [build a basic prototype tutorial](https://prototype-kit.service-manual.nhs.uk/guides/build-basic-prototype/) to familiarise yourself with prototyping.
 
 ## NHS App prototype templates and components
 

--- a/docs/get-started/nhsapp-prototype/setup.md
+++ b/docs/get-started/nhsapp-prototype/setup.md
@@ -16,7 +16,7 @@ You need:
 - [Node.js](https://nodejs.org/en/download) version 20 or higher
 - an HTML text editor, such as [Visual Studio Code (VS Code)](https://code.visualstudio.com/download)
 
-If you're not sure whether the tools are installed – or how to install them – follow the [NHS prototype kit setup guide](https://prototype-kit.service-manual.nhs.uk/install/simple) to get everything you need.
+If you're not sure whether the tools are installed – or how to install them – follow the [NHS prototype kit setup guide](https://prototype-kit.service-manual.nhs.uk/install/) to get everything you need.
 
 ## Download the NHS App prototype
 


### PR DESCRIPTION
Some of these URLs have been renamed (we changed `/how-tos/` to `/guides`) so this updates them.

One of the links - to `/install/simple` - was also broken so this fixes that.