### PR TITLE
Add iOS colour reference

### DIFF
--- a/docs/_includes/layouts/ios.njk
+++ b/docs/_includes/layouts/ios.njk
@@ -1,0 +1,54 @@
+{% extends "./sidebar.njk" %}
+{% from 'nhsapp/components/tag/macro.njk' import nhsappTag %}
+
+{%- from "./partials/side-navigation.njk" import appSideNavigation %}
+
+{% block beforeContent %}
+  {% if title === "iOS" %}
+    {{ breadcrumb({
+      href: "/",
+      text: "Home"
+    }) }}
+  {% else %}
+    {{ breadcrumb({
+      items: [
+        {
+          href: "/",
+          text: "Home"
+        }
+      ],
+      href: "/ios",
+      text: "iOS"
+    }) }}
+  {% endif %}
+{% endblock %}
+
+{% set sidebar %}
+  {{ appSideNavigation({
+    currentPath: page.url,
+    sections: [
+      {
+        items: collections.ios | sort(attribute="data.title")
+      }
+    ]
+  }) }}
+{% endset %}
+
+{% block content %}
+    {{ nhsappTag({
+    text: 'Work in progress',
+    classes: 'nhsapp-tag--blue nhsuk-u-margin-bottom-4'
+    })}}
+
+  {% if tags and "ios" in tags %}
+    <span class="nhsuk-caption-xl">iOS</span>
+  {% endif %}
+  <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
+    {{ title }}
+  </h1>
+  <p>{{ description }}</p>
+  {{ content | safe }}
+  {% if tags and "ios" in tags %}
+    {% include "layouts/partials/feedback-section.njk" %}
+  {% endif %}
+{% endblock %}

--- a/docs/assets/css/_code.scss
+++ b/docs/assets/css/_code.scss
@@ -1,3 +1,5 @@
+// A quick hack to undo some of the default
+// styles for inline code blocks.
 code.app-code--transparent {
   background: transparent !important;
   color: $nhsuk-text-colour !important;

--- a/docs/assets/css/_code.scss
+++ b/docs/assets/css/_code.scss
@@ -1,0 +1,4 @@
+code.app-code--transparent {
+  background: transparent !important;
+  color: $nhsuk-text-colour !important;
+}

--- a/docs/assets/css/_colour.scss
+++ b/docs/assets/css/_colour.scss
@@ -25,10 +25,6 @@
   vertical-align: middle;
   width: nhsuk-spacing(6);
 
-  position: absolute;
-  left: 0;
-  top: math.div(nhsuk-spacing(1), 2);
-
   @include nhsuk-media-query($until: tablet) {
     height: nhsuk-spacing(4);
     width: nhsuk-spacing(4);
@@ -56,10 +52,8 @@
 .app-colour-list__column--name {
   font-weight: normal;
   position: relative;
-  padding-left: nhsuk-spacing(8);
 
   @include nhsuk-media-query($until: tablet) {
-    padding-left: nhsuk-spacing(5);
     padding-bottom: nhsuk-spacing(1);
     padding-top: nhsuk-spacing(1);
   }

--- a/docs/assets/css/_colour.scss
+++ b/docs/assets/css/_colour.scss
@@ -32,6 +32,12 @@
   }
 }
 
+// Bordered swatch. Used when the swatch is the
+// same as the background colour.
+.app-colour-list__swatch--bordered {
+  border-color: nhsuk-colour("grey-4");
+}
+
 .app-colour-list__column {
   padding-left: 0;
   padding-top: nhsuk-spacing(2);

--- a/docs/assets/css/_table.scss
+++ b/docs/assets/css/_table.scss
@@ -1,0 +1,6 @@
+
+// Remove the horizontal border between each row
+.app-table--no-border th,
+.app-table--no-border td {
+  border-bottom-width: 0;
+}

--- a/docs/assets/css/_table.scss
+++ b/docs/assets/css/_table.scss
@@ -1,4 +1,3 @@
-
 // Remove the horizontal border between each row
 .app-table--no-border th,
 .app-table--no-border td {

--- a/docs/assets/css/app.scss
+++ b/docs/assets/css/app.scss
@@ -22,6 +22,7 @@
 @import "docs/assets/css/mobile-iframe";
 @import "docs/assets/css/example";
 @import "docs/assets/css/utilities";
+@import "docs/assets/css/table";
 
 // Add correct spacing around code highlighter and content
 pre {

--- a/docs/assets/css/app.scss
+++ b/docs/assets/css/app.scss
@@ -16,6 +16,7 @@
 @import "docs/assets/css/components/top-nav-native";
 @import "docs/assets/css/components/header-native";
 @import "docs/assets/css/container";
+@import "docs/assets/css/code";
 @import "docs/assets/css/colour";
 @import "docs/assets/css/tabs";
 @import "docs/assets/css/content";

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -193,7 +193,7 @@ All colours will adapt to dark mode, except for those with the 'Only' suffix, wh
         <code class="app-code--transparent nhsuk-u-font-weight-normal">.{{ colour.token }}</code>
       </th>
       <td class="nhsuk-u-padding-0">
-        <span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span>
+        <span class="app-colour-list__swatch {{ "app-colour-list__swatch--bordered" if colour.token == "nhsGrey5" }}" style="background-color:{{ colour.light }}"></span>
       </td>
       <td class="nhsuk-u-padding-0">
         <span class="app-colour-list__swatch" style="background-color:{{ colour.dark if colour.dark else colour.light }}"></span>

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -168,9 +168,9 @@ colourGroups:
         light: "#fff7b1"
 ---
 
-Colours are defined in the NHS iOS App Design as extensions on SwiftUI's `Color` type.
+Colours are defined in the NHS iOS App Design as extensions on SwiftUI's `Color`.
 
-All colours will adapt to dark mode, except for those with the `Only` suffix.
+All colours will adapt to dark mode, except for those with the 'Only' suffix, which are fixed.
 
 {% for group in colourGroups %}
 
@@ -178,24 +178,26 @@ All colours will adapt to dark mode, except for those with the `Only` suffix.
 
 {% if group.description %}<p>{{ group.description }}</p>{% endif %}
 
-<table class="app-colour-list" summary="{{ group.heading }} colour tokens">
+<table class="app-table--no-border">
   <thead>
     <tr>
-      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0" scope="col">Token</th>
-      <td class="app-colour-list__column app-colour-list__column--colour">Light</td>
-      <td class="app-colour-list__column app-colour-list__column--colour">Dark</td>
+      <th>Code</th>
+      <th>Light</th>
+      <th>Dark</th>
     </tr>
   </thead>
   <tbody>
     {%- for colour in group.colours %}
-    <tr class="app-colour-list__row">
-      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0 nhsuk-u-width-full" scope="row"><code>Color.{{ colour.token }}</code></th>
-      <td class="nhsuk-u-padding-0"><span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span></td>
-
+    <tr>
+      <th class="nhsuk-u-width-full">
+        <code class="app-code--transparent nhsuk-u-font-weight-normal">.{{ colour.token }}</code>
+      </th>
+      <td class="nhsuk-u-padding-0">
+        <span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span>
+      </td>
       <td class="nhsuk-u-padding-0">
         <span class="app-colour-list__swatch" style="background-color:{{ colour.dark if colour.dark else colour.light }}"></span>
       </td>
-
     </tr>
     {%- endfor %}
   </tbody>

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -182,16 +182,20 @@ All colours will adapt to dark mode, except for those with the `Only` suffix.
   <thead>
     <tr>
       <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0" scope="col">Token</th>
-      <td class="app-colour-list__column app-colour-list__column--colour">{{ "Light" if group.heading !== "Non-adaptive colours" else "Colour" }}</td>
-      {% if group.heading !== "Non-adaptive colours" %}<td class="app-colour-list__column app-colour-list__column--colour">Dark</td>{% endif %}
+      <td class="app-colour-list__column app-colour-list__column--colour">Light</td>
+      <td class="app-colour-list__column app-colour-list__column--colour">Dark</td>
     </tr>
   </thead>
   <tbody>
     {%- for colour in group.colours %}
     <tr class="app-colour-list__row">
-      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0" scope="row"><code>Color.{{ colour.token }}</code></th>
-      <td class="app-colour-list__column app-colour-list__column--colour" style="position: relative;"><span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span></td>
-      {% if group.heading !== "Non-adaptive colours" %}<td class="app-colour-list__column app-colour-list__column--colour" style="position: relative;">{% if colour.dark %}<span class="app-colour-list__swatch" style="background-color:{{ colour.dark }}"></span>{% endif %}</td>{% endif %}
+      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0 nhsuk-u-width-full" scope="row"><code>Color.{{ colour.token }}</code></th>
+      <td class="nhsuk-u-padding-0"><span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span></td>
+
+      <td class="nhsuk-u-padding-0">
+        <span class="app-colour-list__swatch" style="background-color:{{ colour.dark if colour.dark else colour.light }}"></span>
+      </td>
+
     </tr>
     {%- endfor %}
   </tbody>

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -1,0 +1,201 @@
+---
+layout: layouts/ios.njk
+title: Colour
+tags:
+  - ios
+colourGroups:
+  - heading: Core palette
+    colours:
+      - token: nhsBlue
+        light: "#0060bf"
+        dark: "#2ca2ff"
+      - token: nhsAquaGreen
+        light: "#4aa199"
+        dark: "#58bbb2"
+      - token: nhsBlack
+        light: "#212b33"
+        dark: "#ffffff"
+      - token: nhsGreen
+        light: "#007f3b"
+        dark: "#00c55f"
+      - token: nhsOrange
+        light: "#ed8b00"
+        dark: "#ffa240"
+      - token: nhsPink
+        light: "#ae2573"
+        dark: "#f681ba"
+      - token: nhsPurple
+        light: "#5c338e"
+        dark: "#a988dd"
+      - token: nhsRed
+        light: "#d5281b"
+        dark: "#f76957"
+      - token: nhsWhite
+        light: "#ffffff"
+        dark: "#263037"
+      - token: nhsWarmYellow
+        light: "#ffb81c"
+      - token: nhsYellow
+        light: "#ffeb3b"
+        dark: "#ffffff"
+  - heading: Greyscale
+    colours:
+      - token: nhsGrey1
+        light: "#4c6273"
+        dark: "#c8d3d9"
+      - token: nhsGrey2
+        light: "#778792"
+        dark: "#aab5bc"
+      - token: nhsGrey3
+        light: "#aeb7be"
+        dark: "#7b888f"
+      - token: nhsGrey4
+        light: "#d8dde0"
+        dark: "#4c5a63"
+      - token: nhsGrey5
+        light: "#f0f4f5"
+        dark: "#1b2429"
+  - heading: Dark variants
+    colours:
+      - token: nhsDarkAquaGreen
+        light: "#25514d"
+        dark: "#94faea"
+      - token: nhsDarkBlue
+        light: "#00386e"
+        dark: "#add1ff"
+      - token: nhsDarkGreen
+        light: "#004c23"
+        dark: "#adffc7"
+      - token: nhsDarkOrange
+        light: "#603700"
+        dark: "#ffd2ad"
+      - token: nhsDarkPink
+        light: "#681645"
+        dark: "#ffcce2"
+      - token: nhsDarkPurple
+        light: "#402463"
+        dark: "#daccff"
+      - token: nhsDarkRed
+        light: "#801810"
+        dark: "#ffb5ad"
+      - token: nhsDarkYellow
+        light: "#4c4612"
+        dark: "#ffe799"
+  - heading: Pale variants
+    colours:
+      - token: nhsPaleAquaGreen
+        light: "#c9e3e0"
+        dark: "#1e403d"
+      - token: nhsPaleBlue
+        light: "#ccdff1"
+        dark: "#002f5c"
+      - token: nhsPaleGreen
+        light: "#cce5d8"
+        dark: "#004c23"
+      - token: nhsPaleOrange
+        light: "#fce7cc"
+        dark: "#513000"
+      - token: nhsPalePink
+        light: "#efd3e3"
+        dark: "#541238"
+      - token: nhsPalePurple
+        light: "#ded6e8"
+        dark: "#3f2361"
+      - token: nhsPaleRed
+        light: "#f7d4d1"
+        dark: "#4a1917"
+      - token: nhsPaleYellow
+        light: "#fff7b1"
+        dark: "#423d10"
+  - heading: Prescription
+    colours:
+      - token: nhsPrescriptionGreen
+        light: "#c7eacc"
+      - token: nhsPrescriptionWhite
+        light: "#ffffff"
+        dark: "#ffffff"
+  - heading: Fixed colours
+    description: These use the same colour value in both light and dark mode. Use them when you need a colour that does not change.
+    colours:
+      - token: nhsBlueOnly
+        light: "#005eb8"
+      - token: nhsAquaGreenOnly
+        light: "#4aa199"
+      - token: nhsBlackOnly
+        light: "#232b32"
+      - token: nhsGreenOnly
+        light: "#007f3b"
+      - token: nhsOrangeOnly
+        light: "#ed8b00"
+      - token: nhsPinkOnly
+        light: "#ae2573"
+      - token: nhsPurpleOnly
+        light: "#5c338e"
+      - token: nhsRedOnly
+        light: "#d5281b"
+      - token: nhsWhiteOnly
+        light: "#ffffff"
+      - token: nhsDarkAquaGreenOnly
+        light: "#25514d"
+      - token: nhsDarkBlueOnly
+        light: "#00386e"
+      - token: nhsDarkGreenOnly
+        light: "#004c23"
+      - token: nhsDarkOrangeOnly
+        light: "#5a390f"
+      - token: nhsDarkPinkOnly
+        light: "#681645"
+      - token: nhsDarkPurpleOnly
+        light: "#402463"
+      - token: nhsDarkRedOnly
+        light: "#801810"
+      - token: nhsDarkYellowOnly
+        light: "#4c4612"
+      - token: nhsPaleAquaGreenOnly
+        light: "#c9e3e0"
+      - token: nhsPaleBlueOnly
+        light: "#ccdff1"
+      - token: nhsPaleGreenOnly
+        light: "#cce5d8"
+      - token: nhsPaleOrangeOnly
+        light: "#f8e8cf"
+      - token: nhsPalePinkOnly
+        light: "#efd3e3"
+      - token: nhsPalePurpleOnly
+        light: "#ded6e8"
+      - token: nhsPaleRedOnly
+        light: "#f7d4d1"
+      - token: nhsPaleYellowOnly
+        light: "#fff7b1"
+---
+
+Colours are defined in the NHS iOS App Design as extensions on SwiftUI's `Color` type.
+
+All colours will adapt to dark mode, except for those with the `Only` suffix.
+
+{% for group in colourGroups %}
+
+## {{ group.heading }}
+
+{% if group.description %}<p>{{ group.description }}</p>{% endif %}
+
+<table class="app-colour-list" summary="{{ group.heading }} colour tokens">
+  <thead>
+    <tr>
+      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0" scope="col">Token</th>
+      <td class="app-colour-list__column app-colour-list__column--colour">{{ "Light" if group.heading !== "Non-adaptive colours" else "Colour" }}</td>
+      {% if group.heading !== "Non-adaptive colours" %}<td class="app-colour-list__column app-colour-list__column--colour">Dark</td>{% endif %}
+    </tr>
+  </thead>
+  <tbody>
+    {%- for colour in group.colours %}
+    <tr class="app-colour-list__row">
+      <th class="app-colour-list__column app-colour-list__column--name nhsuk-u-padding-left-0" scope="row"><code>Color.{{ colour.token }}</code></th>
+      <td class="app-colour-list__column app-colour-list__column--colour" style="position: relative;"><span class="app-colour-list__swatch" style="background-color:{{ colour.light }}"></span></td>
+      {% if group.heading !== "Non-adaptive colours" %}<td class="app-colour-list__column app-colour-list__column--colour" style="position: relative;">{% if colour.dark %}<span class="app-colour-list__swatch" style="background-color:{{ colour.dark }}"></span>{% endif %}</td>{% endif %}
+    </tr>
+    {%- endfor %}
+  </tbody>
+</table>
+
+{% endfor %}

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -4,6 +4,12 @@ title: Colour
 tags:
   - ios
 colourGroups:
+  - heading: Accent colour
+    description: This is set as the tint colour, and will be used by some native components by default.
+    colours:
+      - token: nhsAccentColor
+        light: "#005eb8"
+        dark: "#52a0ff"
   - heading: Core palette
     colours:
       - token: nhsBlue

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -113,13 +113,6 @@ colourGroups:
       - token: nhsPaleYellow
         light: "#fff7b1"
         dark: "#423d10"
-  - heading: Prescription
-    colours:
-      - token: nhsPrescriptionGreen
-        light: "#c7eacc"
-      - token: nhsPrescriptionWhite
-        light: "#ffffff"
-        dark: "#ffffff"
   - heading: Fixed colours
     description: These use the same colour value in both light and dark mode. Use them when you need a colour that does not change.
     colours:

--- a/docs/ios/index.md
+++ b/docs/ios/index.md
@@ -1,5 +1,6 @@
 ---
-layout: layouts/base.njk
+layout: layouts/ios.njk
+isIndex: true
 title: iOS
 description: TODO
 ---
@@ -10,8 +11,6 @@ description: TODO
   text: 'Work in progress',
   classes: 'nhsapp-tag--blue nhsuk-u-margin-bottom-4'
 })}}
-
-# iOS
 
 We are transforming the NHS App to be more platform-native.
 

--- a/docs/styles/colour.md
+++ b/docs/styles/colour.md
@@ -19,7 +19,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
   <tbody>
       <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#f7d4d1"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#f7d4d1"></span>
         <code>nhsapp-colour("pale-red")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -28,7 +28,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#fff7b1"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#fff7b1"></span>
         <code>nhsapp-colour("pale-yellow")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -37,16 +37,16 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
         <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#cce5d8"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#cce5d8"></span>
         <code>nhsapp-colour("pale-green")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
       #cce5d8
       </td>
-    </tr>    
+    </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#c9e3e0"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#c9e3e0"></span>
         <code>nhsapp-colour("pale-aqua-green")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -55,7 +55,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#ccdff1"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#ccdff1"></span>
         <code>nhsapp-colour("pale-blue")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -64,7 +64,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#ded6e8"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#ded6e8"></span>
         <code>nhsapp-colour("pale-purple")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -73,7 +73,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#efd3e3"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#efd3e3"></span>
         <code>nhsapp-colour("pale-pink")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -82,7 +82,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#fbe8cc"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#fbe8cc"></span>
         <code>nhsapp-colour("pale-orange")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -103,7 +103,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
   <tbody>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#801810"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#801810"></span>
         <code>nhsapp-colour("dark-red")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -112,7 +112,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
      <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#4c4612"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#4c4612"></span>
         <code>nhsapp-colour("dark-yellow")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -121,7 +121,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#004c23"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#004c23"></span>
         <code>nhsapp-colour("dark-green")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -130,7 +130,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#1e403d"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#1e403d"></span>
         <code>nhsapp-colour("dark-aqua-green")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -139,7 +139,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#00386e"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#00386e"></span>
         <code>nhsapp-colour("dark-blue")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -148,7 +148,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#402463"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#402463"></span>
         <code>nhsapp-colour("dark-purple")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -157,7 +157,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#681645"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#681645"></span>
         <code>nhsapp-colour("dark-pink")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">
@@ -166,7 +166,7 @@ We have extended the [NHS design system colour palette](https://service-manual.n
     </tr>
     <tr class="app-colour-list__row">
       <th class="app-colour-list__column app-colour-list__column--name" scope="row">
-        <span class="app-colour-list__swatch" style="background-color:#5f3800"></span>
+        <span class="app-colour-list__swatch nhsuk-u-margin-right-2" style="background-color:#5f3800"></span>
         <code>nhsapp-colour("dark-orange")</code>
       </th>
       <td class="app-colour-list__column app-colour-list__column--colour">


### PR DESCRIPTION
This adds an initial reference page for the iOS colours.

I used copilot to read the colours from https://github.com/NHSDigital/nhsapp-design-system-ios and copy the names and hexcodes into this page, which worked ok as a one-off but might need a way of keeping it up-to-date somehow, as these colours are bound to change.

This also reveals a couple of bugs in the the colours list itself - `nhsWarmYellow` and `prescriptionGreen` are missing the dark mode variants somehow.