### PR TITLE
Add initial install guide

### DIFF
--- a/docs/_includes/layouts/ios.njk
+++ b/docs/_includes/layouts/ios.njk
@@ -28,7 +28,16 @@
     currentPath: page.url,
     sections: [
       {
+        heading: {
+          text: 'Get started'
+        },
         items: collections.ios | sort(attribute="data.title")
+      },
+      {
+        heading: {
+          text: 'Styles'
+        },
+        items: collections.iosStyles | sort(attribute="data.title")
       }
     ]
   }) }}

--- a/docs/ios/colour.md
+++ b/docs/ios/colour.md
@@ -2,7 +2,7 @@
 layout: layouts/ios.njk
 title: Colour
 tags:
-  - ios
+  - iosStyles
 colourGroups:
   - heading: Accent colour
     description: This is set as the tint colour, and will be used by some native components by default.

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -18,7 +18,7 @@ At the moment, because the package is a private repository, you will need to cre
 3. Give the token a name - this can be the name of your prototype or anything brief and descriptive.
 4. Set 'resource owned' to NHSDigital.
 5. Set the expiration to 366 days.
-7. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that.
+6. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that.
 7. Click 'Add permissions' and search for 'Contents' and select that.
 8. Generate the token, and then copy it somewhere safe. You will need it in the next step.
 

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -16,9 +16,9 @@ At the moment, because the package is a private repository, you will need to cre
 1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub.
 2. Click 'Generate new token'.
 3. Give the token a name - this can be the name of your prototype or anything brief and descriptive.
-4. Set 'resource owned' to NHSDigital.
+4. Set 'resource owner' to NHSDigital.
 5. Set the expiration to 366 days.
-6. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that.
+6. Select 'Only select repositories', then search for `nhsapp-design-system-ios` and select that.
 7. Click 'Add permissions' and search for 'Contents' and select that.
 8. Generate the token, and then copy it somewhere safe. You will need it in the next step.
 

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -15,7 +15,7 @@ At the moment, because the package is a private repository, you will need to cre
 
 1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub.
 2. Click 'Generate new token'.
-3. Give the token a name - this can be the name of your prototype or anything brief and descriptive.
+3. Give the token a name – this can be the name of your prototype or anything brief and descriptive.
 4. Set 'resource owner' to NHSDigital.
 5. Set the expiration to 366 days.
 6. Select 'Only select repositories', then search for `nhsapp-design-system-ios` and select that.

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -9,22 +9,22 @@ The iOS design system for the NHS app is available as a [Swift package](https://
 
 To use it, you’ll need to add the package as dependency to your prototype or production app.
 
-## Adding the package
+## Creating a GitHub personal access token
 
 At the moment, because the package is a private repository, you will need to create a GitHub personal access token to be able to access the code.
 
-To do this:
-
-1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub
-2. Click 'Generate new token'
-3. Give the token a name - this can be the name of your prototype or anything brief and descriptive
-4. Set 'resource owned' to NHSDigital
+1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub.
+2. Click 'Generate new token'.
+3. Give the token a name - this can be the name of your prototype or anything brief and descriptive.
+4. Set 'resource owned' to NHSDigital.
 5. Set the expiration to 366 days.
-7. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
-7. Click 'Add permissions' and search for 'Contents' and select that
+7. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that.
+7. Click 'Add permissions' and search for 'Contents' and select that.
 8. Generate the token, and then copy it somewhere safe. You will need it in the next step.
 
-(In future this will no longer be required once the repository is public)
+In future this will no longer be required once the repository is public
+
+## Adding the package
 
 In Xcode, go to: File → Add Package Dependencies
 

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -18,9 +18,10 @@ To do this:
 1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub
 2. Click 'Generate new token'
 3. Give the token a name and set 'resource owned' to NHSDigital
-4. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
-5. Click 'Add permissions' and search for 'Contents' and select that
-6. Generate the token, and then copy it somewhere safe. You will need it in the next step.
+4. Set the expiration to 366 days.
+5. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
+6. Click 'Add permissions' and search for 'Contents' and select that
+7. Generate the token, and then copy it somewhere safe. You will need it in the next step.
 
 (In future this will no longer be required once the repository is public)
 

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -1,0 +1,39 @@
+---
+layout: layouts/ios.njk
+title: Installing
+tags:
+  - ios
+---
+
+The iOS design system for the NHS app is available as a [Swift package](https://developer.apple.com/documentation/xcode/swift-packages).
+
+To use it, you’ll need to add the package as dependency to your prototype or production app.
+
+## Adding the package
+
+At the moment, because the package is a private repository, you will need to create a GitHub personal access token to be able to access the code.
+
+To do this:
+
+1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub
+2. Click 'Generate new token'
+3. Give the token a name and set 'resource owned' to NHSDigital
+4. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
+5. Click 'Add permissions' and search for 'Contents' and select that
+6. Generate the token, and then copy it somewhere safe. You will need it in the next step.
+
+(In future this will no longer be required once the repository is public)
+
+In Xcode, go to: File → Add Package Dependencies
+
+Enter the repository URL (`https://github.com/NHSDigital/nhsapp-design-system-ios`). You will need to add your personal access token to view it.
+
+For 'Dependency Rule', set it to 'Branch' and 'main'. (In future we will switch to versioned releases.) Select 'Add Package'.
+
+In the dialog box, under 'Add to Target' change 'None' to your app name. Then select 'Add Package' again.
+
+## Updating the package
+
+Whenever there are changes made to the swift package, you will need to update the package within your project.
+
+Do do this, go to File → Packages → Update to Latest Package Versions

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -17,11 +17,12 @@ To do this:
 
 1. Go to [personal access tokens](https://github.com/settings/personal-access-tokens) on GitHub
 2. Click 'Generate new token'
-3. Give the token a name and set 'resource owned' to NHSDigital
-4. Set the expiration to 366 days.
-5. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
-6. Click 'Add permissions' and search for 'Contents' and select that
-7. Generate the token, and then copy it somewhere safe. You will need it in the next step.
+3. Give the token a name - this can be the name of your prototype or anything brief and descriptive
+4. Set 'resource owned' to NHSDigital
+5. Set the expiration to 366 days.
+7. Select 'Only select repositories, then search for `nhsapp-design-system-ios` and select that
+7. Click 'Add permissions' and search for 'Contents' and select that
+8. Generate the token, and then copy it somewhere safe. You will need it in the next step.
 
 (In future this will no longer be required once the repository is public)
 

--- a/docs/ios/typography.md
+++ b/docs/ios/typography.md
@@ -2,7 +2,7 @@
 layout: layouts/ios.njk
 title: Typography
 tags:
-  - ios
+  - iosStyles
 ---
 
 We are still deciding whether or how the native app should use a custom typeface (Frutiger).


### PR DESCRIPTION
This tries to document the steps to add the package to a project.

This will change once the repository becomes public, and when we switch to versioned releases.

Resolves https://github.com/NHSDigital/native-nhsapp-ucd-team/issues/58

<img width="1053" height="601" alt="Screenshot 2026-06-16 at 15 30 56" src="https://github.com/user-attachments/assets/646f971f-0f03-4d84-9d27-a63e4a6ba502" />
