### PR TITLE
Extend example shortcode with Swift code tabs

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -123,10 +123,16 @@ export default function (eleventyConfig) {
       showNunjucksAuto = data.showNunjucks
     }
 
+    // Always show HTML preview/tab unless explicitly disabled
+    let showHtmlAuto = true
+    if (typeof data.showHtml === 'boolean') {
+      showHtmlAuto = data.showHtml
+    }
+
     const rawHtmlCode = nunjucksEnv.renderString(nunjucksCode)
-    const prettyHtmlCode = await prettier.format(rawHtmlCode, {
-      parser: 'html'
-    })
+    const prettyHtmlCode = rawHtmlCode.trim()
+      ? await prettier.format(rawHtmlCode, { parser: 'html' })
+      : ''
 
     const href = `/examples/${examplePath.replace('.njk', '')}`
 
@@ -145,8 +151,13 @@ export default function (eleventyConfig) {
       backlink: data.backlink || data.backLink || false,
       backLinkHref: data.backLinkHref,
       backLinkText: data.backLinkText,
-      arguments: data.arguments, // existing
-      showNunjucks: showNunjucksAuto // computed visibility
+      arguments: data.arguments,
+      showNunjucks: showNunjucksAuto,
+      showHtml: showHtmlAuto,
+      swiftCode: data.swiftCode || null,
+      swiftArguments: data.swiftArguments || null,
+      androidCode: data.androidCode || null,
+      openFirst: data.openFirst === true
     }
     return nunjucksEnv.render('example.njk', templateData)
   })

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -1,3 +1,5 @@
+{% set showHtmlTab = showHtml is not defined or showHtml != false %}
+{%- if showHtmlTab %}
 <div class="app-example">
   <span class="app-example__new-window">
     <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new tab</a>
@@ -22,21 +24,27 @@
   </div>
   {% endif -%}
 </div>
+{% endif -%}
 
-<div class="app-tabs" data-module="app-tabs">
+<div class="app-tabs{% if not showHtmlTab %} app-tabs--no-preview{% endif %}" data-module="app-tabs"{% if openFirst %} data-open-first="true"{% endif %}>
   {% set showNunjucksTab = showNunjucks is not defined or showNunjucks != false %}
   <ul class="app-tabs__list" role="tablist">
-    {%- if showNunjucksTab -%}
-      <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
-      <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}">Nunjucks</a></li>
-    {%- else -%}
-      <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
+    {%- if showHtmlTab -%}
+      {%- if showNunjucksTab -%}
+        <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
+        <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}">Nunjucks</a></li>
+      {%- else -%}
+        <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
+      {%- endif -%}
     {%- endif -%}
     {%- if jsCode %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}">JavaScript</a></li>{% endif -%}
     {%- if figmaLink %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#figma-default-{{ id }}" role="tab" id="tab_figma-default-{{ id }}" aria-controls="figma-default-{{ id }}">Figma</a></li>{% endif -%}
     {%- if vueLink %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#vue-default-{{ id }}" role="tab" id="tab_vue-default-{{ id }}" aria-controls="vue-default-{{ id }}">Vue</a></li>{% endif -%}
+    {%- if swiftCode %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#swift-default-{{ id }}" role="tab" id="tab_swift-default-{{ id }}" aria-controls="swift-default-{{ id }}">Swift</a></li>{% endif -%}
+    {%- if androidCode %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab nhsuk-link--no-visited-state" href="#android-default-{{ id }}" role="tab" id="tab_android-default-{{ id }}" aria-controls="android-default-{{ id }}">Android</a></li>{% endif -%}
   </ul>
 
+  {%- if showHtmlTab %}
   <div class="app-tabs__panel app-tabs__panel--hidden" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
     <button class="app-copy__button" data-module="app-copy" data-clipboard-target="#html-default-{{ id }}-code">Copy code</button>
     <div id="html-default-{{ id }}-code">
@@ -85,6 +93,7 @@
 </div>
 
   </div>
+  {% endif -%}
 
   {% if figmaLink -%}
 <div class="app-tabs__panel nhsuk-u-padding-2 app-tabs__panel--hidden" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">
@@ -101,6 +110,51 @@
   To use the component in your Vue application, install the NHS App Vue Component Library and import the component.
 
   <a href="{{ vueLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View component in Vue (opens in a new tab)</a>
+</div>
+  {% endif -%}
+
+  {% if swiftCode -%}
+<div class="app-tabs__panel app-tabs__panel--hidden" id="swift-default-{{ id }}" role="tabpanel" aria-labelledby="tab_swift-default-{{ id }}">
+
+    {%- if swiftArguments -%}
+      <details class="nhsuk-details nhsuk-u-padding-top-4 nhsuk-u-padding-left-4 nhsuk-u-padding-right-4" data-module="nhsuk-details">
+        <summary class="nhsuk-details__summary">
+          <span class="nhsuk-details__summary-text">
+            Swift options
+          </span>
+        </summary>
+        <div class="nhsuk-details__text">
+          <div class="app-table--scroll">
+            {% set swiftOptionsPath = "ios/" + swiftArguments + "/swift-options.md" %}
+            {% include swiftOptionsPath ignore missing %}
+          </div>
+        </div>
+      </details>
+    {%- endif -%}
+
+  <button class="app-copy__button" data-module="app-copy" data-clipboard-target="#swift-default-{{ id }}-code">Copy code</button>
+
+<div id="swift-default-{{ id }}-code">
+
+```swift
+{{ swiftCode | safe }}
+```
+
+</div>
+</div>
+  {% endif -%}
+
+  {% if androidCode -%}
+<div class="app-tabs__panel app-tabs__panel--hidden" id="android-default-{{ id }}" role="tabpanel" aria-labelledby="tab_android-default-{{ id }}">
+  <button class="app-copy__button" data-module="app-copy" data-clipboard-target="#android-default-{{ id }}-code">Copy code</button>
+
+<div id="android-default-{{ id }}-code">
+
+```kotlin
+{{ androidCode | safe }}
+```
+
+</div>
 </div>
   {% endif -%}
 </div>

--- a/docs/_includes/ios/home-menu/swift-options.md
+++ b/docs/_includes/ios/home-menu/swift-options.md
@@ -1,0 +1,7 @@
+<!-- prettier-ignore-file -->
+
+| Option | Description |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| `accessibilityLabel` | A label to describe the overall menu. This isn't visible but is read out by VoiceOver |
+| `title`              | The visible label for each menu item                                                  |
+| `systemImage`        | The name of the icon from SF Symbols to use for each menu item                        |

--- a/docs/_includes/ios/home-menu/swift-options.md
+++ b/docs/_includes/ios/home-menu/swift-options.md
@@ -1,6 +1,6 @@
 <!-- prettier-ignore-file -->
 
-| Option | Description |
+| Option               | Description                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------- |
 | `accessibilityLabel` | A label to describe the overall menu. This isn't visible but is read out by VoiceOver |
 | `title`              | The visible label for each menu item                                                  |

--- a/docs/assets/css/_tabs.scss
+++ b/docs/assets/css/_tabs.scss
@@ -10,12 +10,15 @@
 
 .app-tabs__list {
   border: 1px solid $nhsuk-border-colour;
-  border-top: 0;
   list-style: none;
   margin: 0;
   padding: 0;
 
   display: flex;
+}
+
+.app-tabs:not(.app-tabs--no-preview) .app-tabs__list {
+  border-top: 0;
 }
 
 .app-tabs__list-item {

--- a/docs/assets/js/tabs.js
+++ b/docs/assets/js/tabs.js
@@ -71,6 +71,10 @@ Tabs.prototype.setupHtml = function () {
     panel.setAttribute('aria-labelledby', this.tabs[i].id)
     panel.classList.add(this.cssHide)
   })
+
+  if (this.container.dataset.openFirst === 'true' && this.tabs[0]) {
+    this.showTab(this.tabs[0])
+  }
 }
 
 Tabs.prototype.onTabClick = function (e) {

--- a/docs/examples/home-menu/home-menu-modal.njk
+++ b/docs/examples/home-menu/home-menu-modal.njk
@@ -1,0 +1,48 @@
+---
+title: Home menu modal sheet
+showHtml: false
+openFirst: true
+swiftCode: |
+  enum HomeDestination: Hashable {
+      case prescriptions
+      case vaccinations
+  }
+
+  struct ContentView: View {
+    @State private var path = NavigationPath()
+    @State private var showGetAccess = false
+    let hasAccess: Bool
+
+    var body: some View {
+      NavigationStack(path: $path) {
+        HomeMenu(accessibilityLabel: "Health services") {
+          HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") {
+            if hasAccess {
+              path.append(HomeDestination.prescriptions)
+            } else {
+              showGetAccess = true
+            }
+          }
+          HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") {
+            if hasAccess {
+              path.append(HomeDestination.vaccinations)
+            } else {
+              showGetAccess = true
+            }
+          }
+        }
+        .navigationDestination(for: HomeDestination.self) { destination in
+          switch destination {
+          case .prescriptions:
+            PrescriptionsView()
+          case .vaccinations:
+            VaccinationsView()
+          }
+        }
+      }
+      .sheet(isPresented: $showGetAccess) {
+        GetAccessView()
+      }
+    }
+  }
+---

--- a/docs/examples/home-menu/home-menu-navigate.njk
+++ b/docs/examples/home-menu/home-menu-navigate.njk
@@ -1,0 +1,35 @@
+---
+title: Home menu navigation
+showHtml: false
+openFirst: true
+swiftCode: |
+  enum HomeDestination: Hashable {
+      case prescriptions
+      case vaccinations
+  }
+
+  struct ContentView: View {
+    @State private var path = NavigationPath()
+
+    var body: some View {
+      NavigationStack(path: $path) {
+        HomeMenu(accessibilityLabel: "Health services") {
+          HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") {
+            path.append(HomeDestination.prescriptions)
+          }
+          HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") {
+            path.append(HomeDestination.vaccinations)
+          }
+        }
+        .navigationDestination(for: HomeDestination.self) { destination in
+          switch destination {
+          case .prescriptions:
+            PrescriptionsView()
+          case .vaccinations:
+            VaccinationsView()
+          }
+        }
+      }
+    }
+  }
+---

--- a/docs/examples/home-menu/home-menu.njk
+++ b/docs/examples/home-menu/home-menu.njk
@@ -1,0 +1,11 @@
+---
+title: Home menu
+showHtml: false
+openFirst: true
+swiftArguments: home-menu
+swiftCode: |
+  HomeMenu(accessibilityLabel: "Health services") {
+    HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") { }
+    HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") { }
+  }
+---

--- a/docs/ios/home-menu.md
+++ b/docs/ios/home-menu.md
@@ -32,20 +32,7 @@ The layout varies by screen size and text size:
 
 Use the home menu within a SwiftUI view:
 
-```swift
-HomeMenu(accessibilityLabel: "Health services") {
-  HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") { }
-  HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") { }
-}
-```
-
-You will need to specify these:
-
-| Option               | Description                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------- |
-| `accessibilityLabel` | A label to describe the overall menu. This isn’t visible but is read out by VoiceOver |
-| `title`              | The visible label for each menu item                                                  |
-| `systemImage`        | The name of the icon from SF Symbols to use for each menu item                        |
+{% example "home-menu/home-menu.njk" %}
 
 ### Actions
 
@@ -53,86 +40,13 @@ Each item will trigger an action when tapped. Specify this using the `action` cl
 
 Usually this will navigate to a new screen. A common pattern is to push a value onto a `NavigationPath` and use the `.navigationDestination(for:)` modifier to map that value to a destination view:
 
-```swift
-enum HomeDestination: Hashable {
-    case prescriptions
-    case vaccinations
-}
-
-struct ContentView: View {
-  @State private var path = NavigationPath()
-
-  var body: some View {
-    NavigationStack(path: $path) {
-      HomeMenu(accessibilityLabel: "Health services") {
-        HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") {
-          path.append(HomeDestination.prescriptions)
-        }
-        HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") {
-          path.append(HomeDestination.vaccinations)
-        }
-      }
-      .navigationDestination(for: HomeDestination.self) { destination in
-        switch destination {
-        case .prescriptions:
-          PrescriptionsView()
-        case .vaccinations:
-          VaccinationsView()
-        }
-      }
-    }
-  }
-}
-```
+{% example "home-menu/home-menu-navigate.njk" %}
 
 The action could also present a view as a modal sheet instead of navigating to it.
 
 For example, if the user does not yet have access to their records, a separate view can be presented to them as a modal sheet:
 
-```swift
-enum HomeDestination: Hashable {
-    case prescriptions
-    case vaccinations
-}
-
-struct ContentView: View {
-  @State private var path = NavigationPath()
-  @State private var showGetAccess = false
-  let hasAccess: Bool
-
-  var body: some View {
-    NavigationStack(path: $path) {
-      HomeMenu(accessibilityLabel: "Health services") {
-        HomeMenuItem(title: "Prescriptions", systemImage: "pills.fill") {
-          if hasAccess {
-            path.append(HomeDestination.prescriptions)
-          } else {
-            showGetAccess = true
-          }
-        }
-        HomeMenuItem(title: "Vaccinations", systemImage: "syringe.fill") {
-          if hasAccess {
-            path.append(HomeDestination.vaccinations)
-          } else {
-            showGetAccess = true
-          }
-        }
-      }
-      .navigationDestination(for: HomeDestination.self) { destination in
-        switch destination {
-        case .prescriptions:
-          PrescriptionsView()
-        case .vaccinations:
-          VaccinationsView()
-        }
-      }
-    }
-    .sheet(isPresented: $showGetAccess) {
-      GetAccessView()
-    }
-  }
-}
-```
+{% example "home-menu/home-menu-modal.njk" %}
 
 ## Accessibility
 


### PR DESCRIPTION
## Summary

- Extends the `{% example %}` shortcode with new frontmatter options: `swiftCode`, `swiftArguments`, `showHtml`, `openFirst`, and `androidCode` (for future use)
- Adds a Swift tab (and Android tab skeleton) to the example tab UI, conditionally shown when the relevant frontmatter is set
- Adds `showHtml: false` to hide the iframe preview and HTML/Nunjucks tabs for native-only components, with a CSS fix to restore the missing top border
- Adds `openFirst: true` to auto-open the first tab on load
- Adds `swiftArguments` to show a collapsible Swift options table, mirroring the existing Nunjucks macro options pattern
- Applies all of the above to the iOS home menu page, replacing raw Swift code blocks with `{% example %}` shortcodes for all three examples (basic usage, navigation, modal sheet)

### Before
<img width="817" height="676" alt="Screenshot 2026-06-26 at 16 12 04" src="https://github.com/user-attachments/assets/ae3db0dc-19f9-4f25-bb48-bf32b146df1d" />

### After

<img width="785" height="470" alt="Screenshot 2026-06-26 at 16 11 28" src="https://github.com/user-attachments/assets/c4cdef6d-c735-44af-8394-0e33f00dced0" /> 
<img width="799" height="829" alt="Screenshot 2026-06-26 at 16 11 37" src="https://github.com/user-attachments/assets/4f7ccb06-a4e7-4c28-bd5c-2ffe6c9a14b1" />


