### PR TITLE
Update guidance on how "try again" buttons should behave on error pages

### DIFF
--- a/docs/examples/error-pages/login.njk
+++ b/docs/examples/error-pages/login.njk
@@ -14,10 +14,10 @@ vueLink:
 
     <h1 class="nhsuk-u-margin-bottom-5">There is a problem logging in</h1>
 
-    <p>Close the NHS App, reopen it and try logging in again.</p>
+    <p>This may be a temporary problem. Go back and try logging in again.</p>
 
     {{ button({
-      text: 'Close the NHS App',
+      text: 'Go back to login',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
 

--- a/docs/examples/error-pages/show-gp-appointments-olc.njk
+++ b/docs/examples/error-pages/show-gp-appointments-olc.njk
@@ -12,14 +12,7 @@ vueLink:
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
 
-    <h1 class="nhsuk-u-margin-bottom-5">There is a problem showing your GP appointments</h1>
-
-    <p>This may be a temporary problem.</p>
-
-    {{ button({
-      text: 'Try again',
-      classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
-    }) }}
+    <h1 class="nhsuk-u-margin-bottom-5">There is still a problem showing your GP appointments</h1>
 
     <p>Contact your GP surgery directly if you need to book or change an appointment now.</p>
 

--- a/docs/examples/error-pages/test-results-follow-up.njk
+++ b/docs/examples/error-pages/test-results-follow-up.njk
@@ -1,0 +1,33 @@
+---
+layout: layouts/example-full-page-mobile.njk
+mobile: true
+title: Error page - Test results follow up
+hub: Your health
+figmaLink: 
+vueLink: 
+---
+
+{% from 'button/macro.njk' import button %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <h1 class="nhsuk-u-margin-bottom-5">There is still a problem showing your test results</h1>
+
+    <p>You can:</p>
+
+    <ul>
+      <li>try again later</li>
+      <li>contact your GP surgery directly</li>
+    </ul>  
+    
+    <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
+
+    <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>
+
+    <h2 class="nhsuk-heading-m">For technical support</h2>
+
+    <p>Make a note of the error code <strong>ze4353</strong> and then <a href="https://www.nhs.uk/contact-us/nhs-app-contact-us/">contact the NHS App team</a>.</p>
+
+  </div>
+</div>

--- a/docs/examples/error-pages/test-results-follow-up.njk
+++ b/docs/examples/error-pages/test-results-follow-up.njk
@@ -14,12 +14,7 @@ vueLink:
 
     <h1 class="nhsuk-u-margin-bottom-5">There is still a problem showing your test results</h1>
 
-    <p>You can:</p>
-
-    <ul>
-      <li>try again later</li>
-      <li>contact your GP surgery directly</li>
-    </ul>  
+    <p>Try again later or contact your GP surgery directly.</p>
     
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 

--- a/docs/examples/error-pages/test-results-follow-up.njk
+++ b/docs/examples/error-pages/test-results-follow-up.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/example-full-page-mobile.njk
 mobile: true
-title: Error page - Test results follow up
+title: Error page - Test results follow-up
 hub: Your health
 figmaLink: 
 vueLink: 

--- a/docs/examples/error-pages/test-results.njk
+++ b/docs/examples/error-pages/test-results.njk
@@ -14,20 +14,16 @@ vueLink:
 
     <h1 class="nhsuk-u-margin-bottom-5">There is a problem showing your test results</h1>
 
-    <p>Try logging out of the NHS App and logging in again.</p>
+    <p>This may be a temporary problem.</p>
 
     {{ button({
-      text: 'Log out',
+      text: 'Try again',
       classes: 'nhsuk-button--secondary nhsapp-button nhsuk-u-margin-top-3'
     }) }}
     
     <h2 class="nhsuk-heading-m">For urgent medical advice</h2>
 
     <p>Use <a href="https://111.nhs.uk/">111 online</a> or <a href="tel: 111">call 111</a>.</p>
-
-    <h2 class="nhsuk-heading-m">For technical support</h2>
-
-    <p>Make a note of the error code <strong>ze4353</strong> and then <a href="https://www.nhs.uk/contact-us/nhs-app-contact-us/">contact the NHS App team</a>.</p>
 
   </div>
 </div>

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -41,23 +41,36 @@ Use the main body text to tell users how to resolve the problem, or to give more
 
 ### 3. Button
 
-Use a secondary button for an action that may help to resolve the problem. This could include:
+Use a secondary button for an action that may help to resolve the problem. For example, this could include:
 
-- "Try again" (refreshing the page)
+- "Try again" 
 - "Log out"
+- "Open device settings"
 
 The button should come straight after the related body text.
 
-{% example "error-pages/referrals.njk" %}
+#### Letting users try again
 
-### 4. Secondary body text
+Include a secondary button with the text "Try again" on error pages when:
 
-Use the space beneath the button to:
+- a user attempts an action (such as starting a service)
+- there is a temporary problem
+- that problem may be resolved if they retry the failed action
 
-- let users know about a different way to access the service
-- give links to another relevant service
+Users should only be able to select the button once. It should either:
+
+- successfully take the action the user originally intended
+- show a follow-on error page if the action still fails, explaining that there is still a problem
+
+On the follow-on page, use the heading: “There is still a problem [describe what was supposed to happen]”. The page should tell users about other ways they can access the service, either in the app or outside of it.
+
+{% example "error-pages/test-results-follow-up.njk" %}
+
+### 4. Giving other options
 
 Always tell users how to complete their task through a different channel. The NHS App is a healthcare service. Errors can delay access to clinical care, and users may be experiencing urgent health needs.
+
+Sometimes the alternative option may be for users to contact their GP surgery directly.
 
 For links to other NHS App services, use a secondary card link.
 
@@ -105,7 +118,7 @@ We should account for these challenges in our designs and continue to research a
 
 We want to learn more about:
 
-- "try again" buttons on errors, and how we can best help users when these fail to solve the problem
+- "Try again" buttons on errors, and how we can best help users when these fail to solve the problem
 - how this guidance could evolve into separate pages covering specific errors
 
 We are in the process of updating the NHS App contact form. This update will remove the need for users to note down error codes on error pages, as these codes will be pre-populated into the form.

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -43,7 +43,7 @@ Use the main body text to tell users how to resolve the problem, or to give more
 
 Use a secondary button for an action that may help to resolve the problem. For example, this could include:
 
-- "Try again" 
+- "Try again"
 - "Log out"
 - "Open device settings"
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -57,7 +57,7 @@ Include a secondary button with the text "Try again" on error pages when:
 - there is a temporary problem
 - it's likely the problem will be resolved immediately if they retry the failed action
 
-Do not include a try again button if your data shows it's unlikely to fix the problem immediately. Instead, you can include the words "Try again later" in the body text of the page, if the problem may be fixed at a later time.
+Do not include a "Try again" button if your data shows it's unlikely to fix the problem immediately. Instead, you can include the words "Try again later" in the body text of the page, if the problem may be fixed at a later time.
 
 Users should only be able to select a "Try again" button once. It should either:
 
@@ -86,7 +86,7 @@ Use the heading "For urgent medical advice" followed by the text "Use [111 onlin
 
 ### 6. Signposting to technical support
 
-If the Service Management Team can help users in the scenario, use the heading "For technical help" followed by the text "Make a note of the error code **xxxxx** and then [contact the NHS App team](https://www.nhs.uk/contact-us/nhs-app-contact-us/)". Insert a relevant error code where the bold text is.
+If the Service Management Team can help users in the scenario, use the heading "For technical support" followed by the text "Make a note of the error code **xxxxx** and then [contact the NHS App team](https://www.nhs.uk/contact-us/nhs-app-contact-us/)". Insert a relevant error code where the bold text is.
 
 ## If a user is logged out
 

--- a/docs/patterns/error-page.md
+++ b/docs/patterns/error-page.md
@@ -53,11 +53,13 @@ The button should come straight after the related body text.
 
 Include a secondary button with the text "Try again" on error pages when:
 
-- a user attempts an action (such as starting a service)
+- a user has attempted an action (such as starting a service)
 - there is a temporary problem
-- that problem may be resolved if they retry the failed action
+- it's likely the problem will be resolved immediately if they retry the failed action
 
-Users should only be able to select the button once. It should either:
+Do not include a try again button if your data shows it's unlikely to fix the problem immediately. Instead, you can include the words "Try again later" in the body text of the page, if the problem may be fixed at a later time.
+
+Users should only be able to select a "Try again" button once. It should either:
 
 - successfully take the action the user originally intended
 - show a follow-on error page if the action still fails, explaining that there is still a problem


### PR DESCRIPTION
Update based on[ this proposal](https://github.com/nhsuk/nhsapp-frontend/issues/119#issuecomment-4421648510) about "try again" buttons, and how they should only work once, then show a follow-up screen.

This has been shared on design system and UCD slack channels, and taken to content crit.

One question is whether we want to go ahead with this change in guidance now, or save it for when we have more supporting analytics evidence (as teams such as SCS are introducing errors with try again buttons at the moment).

<img width="2704" height="16384" alt="localhost_8080_patterns_error-page_ (4)" src="https://github.com/user-attachments/assets/876ed9b5-4892-4108-8a2a-c296bfcf8fe1" />