### PR TITLE
Add some initial guidance on 3 core scrollable view types

### DIFF
--- a/docs/_includes/layouts/ios.njk
+++ b/docs/_includes/layouts/ios.njk
@@ -44,6 +44,12 @@
           text: 'Components'
         },
         items: collections.iosComponents | sort(attribute="data.title")
+      },
+      {
+        heading: {
+          text: 'Patterns'
+        },
+        items: collections.iosPatterns | sort(attribute="data.title")
       }
     ]
   }) }}

--- a/docs/_includes/layouts/ios.njk
+++ b/docs/_includes/layouts/ios.njk
@@ -47,9 +47,9 @@
       },
       {
         heading: {
-          text: 'Patterns'
+          text: 'Layouts'
         },
-        items: collections.iosPatterns | sort(attribute="data.title")
+        items: collections.iosLayouts | sort(attribute="data.title")
       }
     ]
   }) }}

--- a/docs/examples/forms/example.njk
+++ b/docs/examples/forms/example.njk
@@ -1,0 +1,32 @@
+---
+title: Forms
+showHtml: false
+openFirst: true
+swiftCode: |
+  let ratings = [
+    "Very good",
+    "Good",
+    "Neither good nor poor",
+    "Poor",
+    "Very poor"
+  ]
+
+  var body: some View {
+      VStack {
+          Form {
+              Section {
+                  Picker("Rating", selection: $rating) {
+                      ForEach(ratings, id: \.self) { option in
+                          Text(option)
+                      }
+                  }
+                  .pickerStyle(.inline)
+              } header: {
+                  Text("Overall, how would you rate your experience of the service?")
+              }
+          }
+
+          Button("Continue")
+      }
+  }
+---

--- a/docs/examples/list/example.njk
+++ b/docs/examples/list/example.njk
@@ -1,0 +1,17 @@
+---
+title: List
+showHtml: false
+openFirst: true
+swiftCode: |
+  var body: some View {
+      NavigationStack {
+          List(prescriptions) { prescription in
+              NavigationLink(prescription.title, value: prescription)
+          }
+          .navigationDestination(for: Prescription.self) { prescription in
+              PrescriptionDetailView(prescription: prescription)
+          }
+          .navigationTitle("Prescriptions")
+      }
+  }
+---

--- a/docs/examples/scroll-views/example.njk
+++ b/docs/examples/scroll-views/example.njk
@@ -1,0 +1,24 @@
+---
+title: List
+showHtml: false
+openFirst: true
+swiftCode: |
+  var body: some View {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(message.sender)
+                .font(.nhsSubheadline)
+            Text(message.dateSent, style: .date)
+                .font(.nhsSubheadline)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            Text(message.content)
+                .font(.nhsBody)
+        }
+        .padding()
+    }
+    .navigationTitle(message.subject)
+  }
+---

--- a/docs/ios/forms.md
+++ b/docs/ios/forms.md
@@ -1,0 +1,28 @@
+---
+layout: layouts/ios.njk
+title: Forms
+tags:
+  - iosPatterns
+---
+
+Form views let users answer questions.
+
+## When to use
+
+Use a form view when the screen collects user input or configuration, for example using toggles, pickers or text fields.
+
+A form may contain several items, but the items do not change or get reordered, instead the user changes the values within them.
+
+## When not to use
+
+Do not use a form view if the screen contains a list of similar items that the user can navigate to or take actions on, use [list views](/ios/lists) instead.
+
+Do not use a form view if the screen only contains content and buttons or links, use a [scroll view](/ios/forms) instead.
+
+## How to use
+
+This example shows an example of a form:
+
+{% example "forms/example.njk" %}
+
+For full documentation, see [SwiftUI: Form](https://developer.apple.com/documentation/SwiftUI/Form) on the Apple developer documentation website.

--- a/docs/ios/forms.md
+++ b/docs/ios/forms.md
@@ -2,7 +2,7 @@
 layout: layouts/ios.njk
 title: Forms
 tags:
-  - iosPatterns
+  - iosLayouts
 ---
 
 Form views let users answer questions.

--- a/docs/ios/lists.md
+++ b/docs/ios/lists.md
@@ -1,0 +1,34 @@
+---
+layout: layouts/ios.njk
+title: Lists
+tags:
+  - iosPatterns
+---
+
+List views present rows of data in a single column.
+
+## When to use
+
+Use a list view for a screen containing a collection of similar rows backed by data that isn’t fixed, such as messages, appointments or medications.
+
+If the data can be re-ordered by the user, or you want to enable swipe actions on each row.
+
+You can also group rows into sections, for example recurring appointments and one-off appointments.
+
+Each row in the list can be linked to a detail view. When doing this, a chevron will be displayed on the right.
+
+Users using the VoiceOver screen reader will hear the content announced as a list, and the number of items there are. As they navigate through the list, the position within the list will be announced.
+
+## When not to use
+
+Do not use a list view if the screen is prose-heavy, or is list-like but contains a fixed set of options. Instead, use a [scroll view](/ios/scroll-views) or [form view](/ios/forms) instead.
+
+If you're using spacing hacks to make a button or paragraph sit right inside a list, you've picked the wrong container.
+
+## How to use
+
+This example shows a list of prescriptions, with each row linking to a detail view:
+
+{% example "list/example.njk" %}
+
+For full documentation, see [SwiftUI: List](https://developer.apple.com/documentation/SwiftUI/List) on the Apple developer documentation website.

--- a/docs/ios/lists.md
+++ b/docs/ios/lists.md
@@ -2,7 +2,7 @@
 layout: layouts/ios.njk
 title: Lists
 tags:
-  - iosPatterns
+  - iosLayouts
 ---
 
 List views present rows of data in a single column.

--- a/docs/ios/scroll-views.md
+++ b/docs/ios/scroll-views.md
@@ -2,7 +2,7 @@
 layout: layouts/ios.njk
 title: Scroll views
 tags:
-  - iosPatterns
+  - iosLayouts
 ---
 
 Scroll views display content as a vertically scrollable page.

--- a/docs/ios/scroll-views.md
+++ b/docs/ios/scroll-views.md
@@ -1,0 +1,28 @@
+---
+layout: layouts/ios.njk
+title: Scroll views
+tags:
+  - iosPatterns
+---
+
+Scroll views display content as a vertically scrollable page.
+
+## When to use
+
+Use a scroll view for a screen containing primarily text content, for example a message.
+
+You should also use a scroll view if your screen contains a mixture of different kinds of items, for example headings, links and buttons.
+
+## When not to use
+
+Do not use a scroll view if a [list view](/ios/lists) or [form view](/ios/forms) would be more appropriate.
+
+If your screen is very long and contains a mixture of content, lists and forms, consider splitting it up into separate screens.
+
+## How to use
+
+This example shows a scroll view containing a message.
+
+{% example "scroll-views/example.njk" %}
+
+For full documentation, see [SwiftUI: ScrollView](https://developer.apple.com/documentation/SwiftUI/ScrollView) on the Apple developer documentation website.


### PR DESCRIPTION
This tries to take the research and findings from #44 into the differences between `List`, `Form` and `ScrollView` containers and extract it into some initial guidance pages.

Possibly the thing this is missing though is a parent page which contains a bit of the decision tree from https://github.com/NHSDigital/native-nhsapp-ios-prototype/issues/44#issuecomment-4833073561 and then links to 3 pages for more details? Maybe that hints there should be a generic `/ios/patterns` index page?

Or is 'patterns' even the right term here?