### PR TITLE
Add guidance on embedding design system package

### DIFF
--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -38,8 +38,8 @@ After you've added the package, there's one more thing to check, otherwise your 
 
 1. Click on your app's target (not the package) in Xcode.
 2. Go to the General tab.
-3. Scroll down to Frameworks, Libraries, and Embedded Content.
-4. Find NHSDesignSystem in the list.
+3. Scroll down to 'Frameworks, Libraries, and Embedded Content'.
+4. Find `NHSDesignSystem` in the list.
 5. Make sure it says 'Embed & Sign' next to it. If it says 'Do Not Embed', change it.
 
 If you skip this step, your app will still build without any errors – but it will crash as soon as you try to open it on a phone.

--- a/docs/ios/installing.md
+++ b/docs/ios/installing.md
@@ -34,6 +34,16 @@ For 'Dependency Rule', set it to 'Branch' and 'main'. (In future we will switch 
 
 In the dialog box, under 'Add to Target' change 'None' to your app name. Then select 'Add Package' again.
 
+After you've added the package, there's one more thing to check, otherwise your app might crash when you try to run it.
+
+1. Click on your app's target (not the package) in Xcode.
+2. Go to the General tab.
+3. Scroll down to Frameworks, Libraries, and Embedded Content.
+4. Find NHSDesignSystem in the list.
+5. Make sure it says 'Embed & Sign' next to it. If it says 'Do Not Embed', change it.
+
+If you skip this step, your app will still build without any errors – but it will crash as soon as you try to open it on a phone.
+
 ## Updating the package
 
 Whenever there are changes made to the swift package, you will need to update the package within your project.


### PR DESCRIPTION
Adds an extra iOS setup check to prevent runtime crashes when consuming the design system Swift package in Xcode, aligning the docs with the embedding requirement raised in https://github.com/NHSDigital/native-nhsapp-ios-prototype/issues/52.