### PR TITLE
Add guidance for choosing between form and list views

### DIFF
--- a/docs/ios/forms.md
+++ b/docs/ios/forms.md
@@ -13,11 +13,13 @@ Use a form view when the screen collects user input or configuration, for exampl
 
 A form may contain several items, but the items do not change or get reordered, instead the user changes the values within them.
 
+This includes screens that look like a list, for example a set of toggle rows for a multiple-choice question. If the rows are fixed and not backed by data, use a form view.
+
 ## When not to use
 
 Do not use a form view if the screen contains a list of similar items that the user can navigate to or take actions on, use [list views](/ios/lists) instead.
 
-Do not use a form view if the screen only contains content and buttons or links, use a [scroll view](/ios/forms) instead.
+If the screen only contains content and buttons or links, use a [scroll view](/ios/scroll-views) instead.
 
 ## How to use
 

--- a/docs/ios/forms.md
+++ b/docs/ios/forms.md
@@ -13,7 +13,7 @@ Use a form view when the screen collects user input or configuration, for exampl
 
 A form may contain several items, but the items do not change or get reordered, instead the user changes the values within them.
 
-This includes screens that look like a list, for example a set of toggle rows for a multiple-choice question. If the rows are fixed and not backed by data, use a form view.
+Forms can include screens that look like a list, for example a set of toggle rows for a multiple-choice question. If the rows are fixed and not backed by data, use a form view.
 
 ## When not to use
 


### PR DESCRIPTION
Adds a sentence to the "When to use" section clarifying that screens with a fixed set of input controls — such as toggle rows — belong in a form view, not a list view. 

Also fixes a broken link in "When not to use" that pointed to `/ios/forms` instead of `/ios/scroll-views.`