### PR TITLE
Make clear the overlay guidance is work in progress

### DIFF
--- a/docs/patterns/access-web-journeys.md
+++ b/docs/patterns/access-web-journeys.md
@@ -14,6 +14,11 @@ tags:
 
 How to adapt your web journey so users can access it in the native NHS App, using a web overlay.
 
+<div class="nhsuk-inset-text">
+  <span class="nhsuk-u-visually-hidden">Information: </span>
+  <p>This guidance is part of our work to prepare for <a href="https://design-history.nhsapp.service.nhs.uk/native/2026/01/exploring-a-spectrum-of-possibilities/">building a more native version of the NHS App</a>.</p>
+</div>
+
 ## Overview
 
 For the first native NHS App release, users will start their journeys on native menu screens. If they then select a website-hosted NHS App service from one of those menu screens, it will open in a web overlay.
@@ -117,7 +122,7 @@ Do not include an alert:
 
 <img class="app-image--no-border" src="/assets/images/web-overlay/close-alert-message.png" alt="Video showing the alert content. The text is 'Exit this service? Your progress will not be saved' and there are buttons to cancel or exit.">
 
-Alerts should consistently use the content shown in the example above, which adheres to iOS and Android platform design guidance.
+We are currently researching and agreeing on a [content pattern for the alert content](https://github.com/NHSDigital/native-nhsapp-ucd-team/issues/69).
 
 ### Open in-journey links in a sheet
 

--- a/docs/patterns/access-web-journeys.md
+++ b/docs/patterns/access-web-journeys.md
@@ -8,16 +8,16 @@ tags:
   - helpUsers
 ---
 
-<strong class="nhsapp-tag nhsapp-tag--blue nhsuk-u-margin-bottom-4">
+<strong class="nhsapp-tag nhsapp-tag--blue nhsuk-u-margin-bottom-1">
   Work in progress
 </strong>
-
-How to adapt your web journey so users can access it in the native NHS App, using a web overlay.
 
 <div class="nhsuk-inset-text">
   <span class="nhsuk-u-visually-hidden">Information: </span>
   <p>This guidance is part of our work to prepare for <a href="https://design-history.nhsapp.service.nhs.uk/native/2026/01/exploring-a-spectrum-of-possibilities/">building a more native version of the NHS App</a>.</p>
 </div>
+
+How to adapt your web journey so users can access it in the native NHS App, using a web overlay.
 
 ## Overview
 


### PR DESCRIPTION
The overlay guidance is live on the NHS App design system website. From speaking with Mike yesterday, we're fine with this, but we might want to make it extra clear that it relates to some upcoming work (on top of the "Work in progress" tag).

This PR adds:

- inset text at the top
- a note explaining that we're still looking at the modal content

Feedback welcome! 