### PR TITLE
Add default sizes to iOS font table

### DIFF
--- a/docs/ios/typography.md
+++ b/docs/ios/typography.md
@@ -29,7 +29,7 @@ The styles are defined relative to the native SwiftUI Font styles - this means t
 | `.nhsCaption`     | `.caption`         | 12pt         |
 | `.nhsCaption2`    | `.caption2`        | 11pt         |
 
-All styles are Regular weight except `.nhsHeadline`, which is Semibold.
+All styles are Regular weight except `.nhsHeadline`, which is Bold.
 
 ## Custom sizes
 

--- a/docs/ios/typography.md
+++ b/docs/ios/typography.md
@@ -15,19 +15,21 @@ The design system supports these styles which match the [named font properties](
 
 The styles are defined relative to the native SwiftUI Font styles - this means that they scale with Dynamic Type.
 
-| Font style        | SwiftUI equivalent |
-| ----------------- | ------------------ |
-| `.nhsLargeTitle`  | `.largeTitle`      |
-| `.nhsTitle`       | `.Title`           |
-| `.nhsTitle2`      | `.title2`          |
-| `.nhsTitle3`      | `.title3`          |
-| `.nhsHeadline`    | `.headline`        |
-| `.nhsSubheadline` | `.subheadline`     |
-| `.nhsBody`        | `.body`            |
-| `.nhsCallout`     | `.callout`         |
-| `.nhsFootnote`    | `.footnote`        |
-| `.nhsCaption`     | `.caption`         |
-| `.nhsCaption2`    | `.caption2`        |
+| Font style        | SwiftUI equivalent | Default size |
+| ----------------- | ------------------ | ------------ |
+| `.nhsLargeTitle`  | `.largeTitle`      | 34pt         |
+| `.nhsTitle`       | `.title`           | 28pt         |
+| `.nhsTitle2`      | `.title2`          | 22pt         |
+| `.nhsTitle3`      | `.title3`          | 20pt         |
+| `.nhsHeadline`    | `.headline`        | 17pt         |
+| `.nhsSubheadline` | `.subheadline`     | 15pt         |
+| `.nhsBody`        | `.body`            | 17pt         |
+| `.nhsCallout`     | `.callout`         | 16pt         |
+| `.nhsFootnote`    | `.footnote`        | 13pt         |
+| `.nhsCaption`     | `.caption`         | 12pt         |
+| `.nhsCaption2`    | `.caption2`        | 11pt         |
+
+All styles are Regular weight except `.nhsHeadline`, which is Semibold.
 
 ## Custom sizes
 


### PR DESCRIPTION
<img width="849" height="1101" alt="Screenshot 2026-07-29 at 15 53 04" src="https://github.com/user-attachments/assets/ff12afe5-5cf1-4d7b-96df-2aab1c643db2" />

