### PR TITLE
ci: switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: npm ci
 
@@ -30,7 +32,6 @@ jobs:
           files: ./dist/nhsapp-frontend-${{ steps.get_version.outputs.VERSION }}.zip
 
       - name: Publish NPM package
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           IS_PRERELEASE: ${{ github.event.release.prerelease }}


### PR DESCRIPTION
### Summary

Replaces the `NODE_AUTH_TOKEN` secret with npm's OIDC Trusted Publisher flow. No more tokens to rotate.

### Changes
- Add `id-token: write` permission
- Add `registry-url` to `setup-node`
- Add `--provenance` flag to `npm publish` (supply-chain transparency)
- Remove `NODE_AUTH_TOKEN` env var

### Prerequisites
Trusted Publisher has been configured on npmjs.com for `nhsuk/nhsapp-frontend` → `publish.yaml`.