### PR TITLE
Add titleHtml option for cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🆕 New features
 
 - Added filled variant of the profile icon - [pull request #554](https://github.com/nhsuk/nhsapp-frontend/pull/554)
+- Added `titleHtml` option to the card component, as an alternative to `title` for when HTML content is needed - [issue #560](https://github.com/nhsuk/nhsapp-frontend/issues/560)
 
 ## `v5.0.3` - 26 November 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🆕 New features
 
 - Added filled variant of the profile icon - [pull request #554](https://github.com/nhsuk/nhsapp-frontend/pull/554)
-- Added `titleHtml` option to the card component, as an alternative to `title` for when HTML content is needed - [issue #560](https://github.com/nhsuk/nhsapp-frontend/issues/560)
+- Added `titleHtml` option to the card component, as an alternative to `title` for when HTML content is needed - [pull request #561](https://github.com/nhsuk/nhsapp-frontend/pull/561)
 
 ## `v5.0.3` - 26 November 2025
 

--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -37,15 +37,15 @@
         <a href="{{ params.href }}"
            class="nhsapp-card__link nhsuk-link--no-visited-state {{ params.titleClasses if params.titleClasses }}"
            {%- if params.linkAriaLabel %} aria-label="{{ params.linkAriaLabel }}"{% endif %}>
-          {{ params.title }}
+          {{ params.titleHtml | safe if params.titleHtml else params.title }}
         </a>
       {%- else -%}
         {%- if params.headingLevel -%}
           <h{{ params.headingLevel }} class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">
-            {{ params.title }}
+            {{ params.titleHtml | safe if params.titleHtml else params.title }}
           </h{{ params.headingLevel }}>
         {%- else -%}
-          <p class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">{{ params.title }}</p>
+          <p class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">{{ params.titleHtml | safe if params.titleHtml else params.title }}</p>
         {%- endif -%}
       {%- endif -%}
 

--- a/src/components/card/macro-options-card-group.md
+++ b/src/components/card/macro-options-card-group.md
@@ -13,7 +13,8 @@
 | classes                        | string  | no          | Classes for the card group.                                                                                                                   |
 | attributes                     | object  | no          | HTML attributes for the card group (data-_ or aria-_).                                                                                        |
 | cards                          | array   | yes         | Array of card objects.                                                                                                                        |
-| cards[]title                   | string  | yes         | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph.                               |
+| cards[]title                   | string  | conditional | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph. Ignored if `titleHtml` is given. |
+| cards[]titleHtml               | string  | conditional | HTML title (allows markup). Overrides `title`.                                                                                                |
 | cards[]href                    | string  | conditional | Makes the `title` a link when provided.                                                                                                       |
 | cards[]linkAriaLabel           | string  | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                                                   |
 | cards[]headingLevel            | number  | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.                                   |

--- a/src/components/card/macro-options-card-group.md
+++ b/src/components/card/macro-options-card-group.md
@@ -1,37 +1,37 @@
 <!-- prettier-ignore-file -->
 
-| Name                           | Type    | Required    | Description                                                                                                                                   |
-| ------------------------------ | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| heading                        | string  | conditional | Text to use for the heding of the card group. If `headingHtml` is provided, the `heading` argument will be ignored.                           |
-| headingHtml                    | string  | conditional | HTML to use for the heading of the card group. If `headingHtml` is provided, the `heading` argument will be ignored.                          |
-| headingLevel                   | number  | conditional | Heading level (2–6) for the `heading`. Defaults to 2 when not set. If `headingHtml` is provided, the `headingLevel` argument will be ignored. |
-| description                    | string  | conditional | Plain text shown under the group heading. If `descriptionHtml` is provided, the `description` argument will be ignored.                       |
-| descriptionHtml                | string  | conditional | HTML version of the description. If `descriptionHtml` is provided, the `description` argument will be ignored..                               |
-| stacked                        | boolean | no          | Adds `nhsapp-cards--stacked` class to card group.                                                                                             |
-| isListItem                     | boolean | no          | If true (default) wrapper is `<ul>` with each card as `<li>`. If false uses `<div>` wrappers.                                                 |
-| id                             | string  | no          | ID for the card group.                                                                                                                        |
-| classes                        | string  | no          | Classes for the card group.                                                                                                                   |
-| attributes                     | object  | no          | HTML attributes for the card group (data-_ or aria-_).                                                                                        |
-| cards                          | array   | yes         | Array of card objects.                                                                                                                        |
+| Name                           | Type    | Required    | Description                                                                                                                                      |
+| ------------------------------ | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| heading                        | string  | conditional | Text to use for the heding of the card group. If `headingHtml` is provided, the `heading` argument will be ignored.                              |
+| headingHtml                    | string  | conditional | HTML to use for the heading of the card group. If `headingHtml` is provided, the `heading` argument will be ignored.                             |
+| headingLevel                   | number  | conditional | Heading level (2–6) for the `heading`. Defaults to 2 when not set. If `headingHtml` is provided, the `headingLevel` argument will be ignored.    |
+| description                    | string  | conditional | Plain text shown under the group heading. If `descriptionHtml` is provided, the `description` argument will be ignored.                          |
+| descriptionHtml                | string  | conditional | HTML version of the description. If `descriptionHtml` is provided, the `description` argument will be ignored..                                  |
+| stacked                        | boolean | no          | Adds `nhsapp-cards--stacked` class to card group.                                                                                                |
+| isListItem                     | boolean | no          | If true (default) wrapper is `<ul>` with each card as `<li>`. If false uses `<div>` wrappers.                                                    |
+| id                             | string  | no          | ID for the card group.                                                                                                                           |
+| classes                        | string  | no          | Classes for the card group.                                                                                                                      |
+| attributes                     | object  | no          | HTML attributes for the card group (data-_ or aria-_).                                                                                           |
+| cards                          | array   | yes         | Array of card objects.                                                                                                                           |
 | cards[]title                   | string  | conditional | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph. Ignored if `titleHtml` is given. |
-| cards[]titleHtml               | string  | conditional | HTML title (allows markup). Overrides `title`.                                                                                                |
-| cards[]href                    | string  | conditional | Makes the `title` a link when provided.                                                                                                       |
-| cards[]linkAriaLabel           | string  | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                                                   |
-| cards[]headingLevel            | number  | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.                                   |
-| cards[]titleClasses            | string  | no          | Classes for the title element.                                                                                                                |
-| cards[]containerClasses        | string  | no          | Classes for the inner container.                                                                                                              |
-| cards[]description             | string  | conditional | Plain text description below the title. Ignored if `descriptionHtml` is given.                                                                |
-| cards[]descriptionHtml         | string  | conditional | HTML description (allows markup). Overrides `description`.                                                                                    |
-| cards[]descriptionClasses      | string  | no          | Classes for the `description`.                                                                                                                |
-| cards[]aboveContent.html       | string  | no          | HTML shown above the title (for example a tag).                                                                                               |
-| cards[]footer.html             | string  | no          | HTML shown in the footer.                                                                                                                     |
-| cards[]img{}.src               | string  | conditional | Image URL. Adds an image section when present.                                                                                                |
-| cards[]img{}.alt               | string  | no          | Image alt text. Leave empty only if purely decorative.                                                                                        |
-| cards[]badgeLarge{}.count      | number  | conditional | Number for the large badge. Badge appears only when `count > 0`.                                                                              |
-| cards[]badgeLarge{}.label      | string  | yes         | Visually hidden text read after the number.                                                                                                   |
-| cards[]badgeLarge{}.id         | string  | no          | ID attribute for the badge.                                                                                                                   |
-| cards[]badgeLarge{}.classes    | string  | no          | Classes for the badge.                                                                                                                        |
-| cards[]badgeLarge{}.attributes | object  | no          | HTML attributes for the badge (e.g. `data-*`, `aria-*`).                                                                                      |
-| cards[]id                      | string  | no          | ID for the card.                                                                                                                              |
-| cards[]classes                 | string  | no          | Classes for the card.                                                                                                                         |
-| cards[]attributes              | object  | no          | HTML attributes for the card (e.g. `data-*`, `aria-*`).                                                                                       |
+| cards[]titleHtml               | string  | conditional | HTML title (allows markup). Overrides `title`.                                                                                                   |
+| cards[]href                    | string  | conditional | Makes the `title` a link when provided.                                                                                                          |
+| cards[]linkAriaLabel           | string  | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                                                      |
+| cards[]headingLevel            | number  | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.                                      |
+| cards[]titleClasses            | string  | no          | Classes for the title element.                                                                                                                   |
+| cards[]containerClasses        | string  | no          | Classes for the inner container.                                                                                                                 |
+| cards[]description             | string  | conditional | Plain text description below the title. Ignored if `descriptionHtml` is given.                                                                   |
+| cards[]descriptionHtml         | string  | conditional | HTML description (allows markup). Overrides `description`.                                                                                       |
+| cards[]descriptionClasses      | string  | no          | Classes for the `description`.                                                                                                                   |
+| cards[]aboveContent.html       | string  | no          | HTML shown above the title (for example a tag).                                                                                                  |
+| cards[]footer.html             | string  | no          | HTML shown in the footer.                                                                                                                        |
+| cards[]img{}.src               | string  | conditional | Image URL. Adds an image section when present.                                                                                                   |
+| cards[]img{}.alt               | string  | no          | Image alt text. Leave empty only if purely decorative.                                                                                           |
+| cards[]badgeLarge{}.count      | number  | conditional | Number for the large badge. Badge appears only when `count > 0`.                                                                                 |
+| cards[]badgeLarge{}.label      | string  | yes         | Visually hidden text read after the number.                                                                                                      |
+| cards[]badgeLarge{}.id         | string  | no          | ID attribute for the badge.                                                                                                                      |
+| cards[]badgeLarge{}.classes    | string  | no          | Classes for the badge.                                                                                                                           |
+| cards[]badgeLarge{}.attributes | object  | no          | HTML attributes for the badge (e.g. `data-*`, `aria-*`).                                                                                         |
+| cards[]id                      | string  | no          | ID for the card.                                                                                                                                 |
+| cards[]classes                 | string  | no          | Classes for the card.                                                                                                                            |
+| cards[]attributes              | object  | no          | HTML attributes for the card (e.g. `data-*`, `aria-*`).                                                                                          |

--- a/src/components/card/macro-options-card.md
+++ b/src/components/card/macro-options-card.md
@@ -1,26 +1,26 @@
 <!-- prettier-ignore-file -->
 
-| Name                    | Type   | Required    | Description                                                                                                     |
-| ----------------------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
+| Name                    | Type   | Required    | Description                                                                                                                                      |
+| ----------------------- | ------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | title                   | string | conditional | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph. Ignored if `titleHtml` is given. |
-| titleHtml               | string | conditional | HTML title (allows markup). Overrides `title`.                                                                  |
-| href                    | string | conditional | Makes the `title` a link when provided.                                                                         |
-| linkAriaLabel           | string | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                     |
-| headingLevel            | number | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.     |
-| titleClasses            | string | no          | Classes for the title element.                                                                                  |
-| containerClasses        | string | no          | Classes for the inner container.                                                                                |
-| description             | string | conditional | Plain text description below the title. Ignored if `descriptionHtml` is given.                                  |
-| descriptionHtml         | string | conditional | HTML description (allows markup). Overrides `description`.                                                      |
-| descriptionClasses      | string | no          | Classes for the `description`.                                                                                  |
-| aboveContent.html       | string | no          | HTML shown above the title (for example a tag).                                                                 |
-| footer.html             | string | no          | HTML shown in the footer.                                                                                       |
-| img{}.src               | string | conditional | Image URL. Adds an image section when present.                                                                  |
-| img{}.alt               | string | no          | Image alt text. Leave empty only if purely decorative.                                                          |
-| badgeLarge{}.count      | number | conditional | Number for the large badge. Badge appears only when `count > 0`.                                                |
-| badgeLarge{}.label      | string | yes         | Visually hidden text read after the number.                                                                     |
-| badgeLarge{}.id         | string | no          | ID attribute for the badge.                                                                                     |
-| badgeLarge{}.classes    | string | no          | Classes for the badge.                                                                                          |
-| badgeLarge{}.attributes | object | no          | HTML attributes for the badge (e.g. `data-*`, `aria-*`).                                                        |
-| id                      | string | no          | ID for the card.                                                                                                |
-| classes                 | string | no          | Classes for the card.                                                                                           |
-| attributes              | object | no          | HTML attributes for the card (e.g. `data-*`, `aria-*`).                                                         |
+| titleHtml               | string | conditional | HTML title (allows markup). Overrides `title`.                                                                                                   |
+| href                    | string | conditional | Makes the `title` a link when provided.                                                                                                          |
+| linkAriaLabel           | string | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                                                      |
+| headingLevel            | number | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.                                      |
+| titleClasses            | string | no          | Classes for the title element.                                                                                                                   |
+| containerClasses        | string | no          | Classes for the inner container.                                                                                                                 |
+| description             | string | conditional | Plain text description below the title. Ignored if `descriptionHtml` is given.                                                                   |
+| descriptionHtml         | string | conditional | HTML description (allows markup). Overrides `description`.                                                                                       |
+| descriptionClasses      | string | no          | Classes for the `description`.                                                                                                                   |
+| aboveContent.html       | string | no          | HTML shown above the title (for example a tag).                                                                                                  |
+| footer.html             | string | no          | HTML shown in the footer.                                                                                                                        |
+| img{}.src               | string | conditional | Image URL. Adds an image section when present.                                                                                                   |
+| img{}.alt               | string | no          | Image alt text. Leave empty only if purely decorative.                                                                                           |
+| badgeLarge{}.count      | number | conditional | Number for the large badge. Badge appears only when `count > 0`.                                                                                 |
+| badgeLarge{}.label      | string | yes         | Visually hidden text read after the number.                                                                                                      |
+| badgeLarge{}.id         | string | no          | ID attribute for the badge.                                                                                                                      |
+| badgeLarge{}.classes    | string | no          | Classes for the badge.                                                                                                                           |
+| badgeLarge{}.attributes | object | no          | HTML attributes for the badge (e.g. `data-*`, `aria-*`).                                                                                         |
+| id                      | string | no          | ID for the card.                                                                                                                                 |
+| classes                 | string | no          | Classes for the card.                                                                                                                            |
+| attributes              | object | no          | HTML attributes for the card (e.g. `data-*`, `aria-*`).                                                                                          |

--- a/src/components/card/macro-options-card.md
+++ b/src/components/card/macro-options-card.md
@@ -2,7 +2,8 @@
 
 | Name                    | Type   | Required    | Description                                                                                                     |
 | ----------------------- | ------ | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| title                   | string | yes         | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph. |
+| title                   | string | conditional | The card title text. Renders as: link (if `href`), heading (if `headingLevel` and no `href`), else a paragraph. Ignored if `titleHtml` is given. |
+| titleHtml               | string | conditional | HTML title (allows markup). Overrides `title`.                                                                  |
 | href                    | string | conditional | Makes the `title` a link when provided.                                                                         |
 | linkAriaLabel           | string | no          | `aria-label` for the title link. Use only if the visible text is not clear.                                     |
 | headingLevel            | number | conditional | Heading level (2–6) used only when there is no `href`. If not set (and no `href`) the title is a paragraph.     |


### PR DESCRIPTION
This allows you to set HTML within the title section of a card, for example to add an unread badge, without having to use the `| safe` filter.

Resolves #560