### PR TITLE
Add Nunjucks version of card with small badge

### DIFF
--- a/docs/examples/cards/card-messages.njk
+++ b/docs/examples/cards/card-messages.njk
@@ -1,45 +1,43 @@
 ---
 layout: layouts/example.njk
 title: Card messages inbox
-showNunjucks: false
+arguments: card
 ---
 
-<ul class="nhsapp-cards nhsapp-cards--stacked">
-  <li class="nhsapp-card nhsuk-u-padding-left-6">
-    <div class="nhsapp-card__container nhsuk-u-padding-left-0">
-      <div class="nhsapp-card__content">
-        <div class="nhsapp-card__above">
-          <p aria-hidden="true" class="nhsuk-body-s nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-0">1:02pm</p>
-        </div>
-        <a href="#" class="nhsapp-card__link nhsuk-link--no-visited-state">
-          <span class="nhsapp-badge-small nhsapp-badge-small--absolute">
-            <span class="nhsapp-badge-small__indicator" aria-hidden="true"></span>
-            <span class="nhsuk-u-visually-hidden">Unread message</span>
-          </span>Portland Street Great Westood Surgery
-          <span class="nhsuk-u-visually-hidden">received today at 1:02pm</span>
-        </a>
-        <div class="nhsapp-card__below">
-          <p class="nhsuk-u-margin-top-1 nhsapp-u-truncate-two-lines nhsuk-u-secondary-text-colour">Patient survey reminder. The Patient feedback survey is about to close. Have your say about Portland Street Great Westood Surgery by providing us with your thoughts.</p>
-        </div>
-      </div>
-      <svg class="nhsapp-icon nhsapp-icon--chevron-right" xmlns="http://www.w3.org/2000/svg" height="2rem" width="2rem" viewBox="0 0 24 24" > <path d="M8.82 19.11a.97.97 0 0 1-.72-.31.996.996 0 0 1 .03-1.41l5.61-5.38-5.6-5.25c-.4-.38-.42-1.01-.05-1.41.38-.4 1.01-.42 1.41-.05l6.37 5.97c.2.19.31.45.32.72s-.11.54-.31.73l-6.37 6.11c-.19.19-.44.28-.69.28Z" /> </svg> 
-    </div>
-  </li>
-  <li class="nhsapp-card nhsuk-u-padding-left-6">
-    <div class="nhsapp-card__container nhsuk-u-padding-left-0">
-      <div class="nhsapp-card__content">
-        <div class="nhsapp-card__above">
-          <p aria-hidden="true" class="nhsuk-body-s nhsuk-u-margin-bottom-0">15 Mar 2024</p>
-        </div>
-        <a href="#" class="nhsapp-card__link nhsuk-link--no-visited-state">
-          Range surgery
-          <span class="nhsuk-u-visually-hidden">received on 15 March 2024 at 9:00am</span>
-        </a>
-        <div class="nhsapp-card__below">
-          <p class="nhsuk-u-margin-top-1 nhsapp-u-truncate-two-lines nhsuk-u-secondary-text-colour">Reminder of your telephone appointment with your GP on Friday 23 October at 1:30pm.</p>
-        </div>
-      </div>
-      <svg class="nhsapp-icon nhsapp-icon--chevron-right" xmlns="http://www.w3.org/2000/svg" height="2rem" width="2rem" viewBox="0 0 24 24" > <path d="M8.82 19.11a.97.97 0 0 1-.72-.31.996.996 0 0 1 .03-1.41l5.61-5.38-5.6-5.25c-.4-.38-.42-1.01-.05-1.41.38-.4 1.01-.42 1.41-.05l6.37 5.97c.2.19.31.45.32.72s-.11.54-.31.73l-6.37 6.11c-.19.19-.44.28-.69.28Z" /> </svg> 
-    </div>
-  </li>
-</ul>
+{% from 'nhsapp/components/card/macro.njk' import nhsappCardGroup %}
+{% from 'nhsapp/components/badge/small/macro.njk' import nhsappBadgeSmall %}
+
+{% set card1TitleHtml %}
+  {{ nhsappBadgeSmall({ positionAbsolute: true, label: 'Unread message' }) -}}
+  Portland Street Great Westood Surgery<span class="nhsuk-u-visually-hidden">received today at 1:02pm</span>
+{% endset %}
+
+{% set card2TitleHtml %}Range surgery<span class="nhsuk-u-visually-hidden">received on 15 March 2024 at 9:00am</span>{% endset %}
+
+{{ nhsappCardGroup({
+  stacked: true,
+  cards: [
+    {
+      classes: 'nhsuk-u-padding-left-6',
+      containerClasses: 'nhsuk-u-padding-left-0',
+      aboveContent: { 
+        html: '<p aria-hidden="true" class="nhsuk-body-s nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-0">1:02pm</p>'
+      },
+      href: '#',
+      titleHtml: card1TitleHtml,
+      description: 'Patient survey reminder. The Patient feedback survey is about to close. Have your say about Portland Street Great Westood Surgery by providing us with your thoughts.',
+      descriptionClasses: 'nhsuk-u-secondary-text-colour nhsapp-u-truncate-two-lines nhsuk-u-margin-top-1'
+    },
+    {
+      classes: 'nhsuk-u-padding-left-6',
+      containerClasses: 'nhsuk-u-padding-left-0',
+      aboveContent: { 
+        html: '<p aria-hidden="true" class="nhsuk-body-s nhsuk-u-margin-bottom-0">15 Mar 2024</p>'
+      },
+      href: '#',
+      titleHtml: card2TitleHtml,
+      description: 'Reminder of your telephone appointment with your GP on Friday 23 October at 1:30pm.',
+      descriptionClasses: 'nhsuk-u-secondary-text-colour nhsapp-u-truncate-two-lines nhsuk-u-margin-top-1'
+    }
+  ]
+}) }}


### PR DESCRIPTION
This shows how to use Nunjucks to setup the 'messages' pattern using the card macro with the small badge macro - mainly for use in prototypes using the NHS Prototype kit.

This requires version 5.1.0 of `nhsapp-frontend` to make use of the new `titleHtml` option.