### PR TITLE
Update to NHS.UK frontend v10.6.1 and fix Sass deprecations

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import nunjucks from 'nunjucks'
-import * as sass from 'sass'
+import * as sass from 'sass-embedded'
 import fs from 'fs-extra'
 import { EleventyHtmlBasePlugin } from '@11ty/eleventy'
 import markdownIt from 'markdown-it'

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,11 +6,8 @@ import { EleventyHtmlBasePlugin } from '@11ty/eleventy'
 import markdownIt from 'markdown-it'
 import anchor from 'markdown-it-anchor'
 import markdownItAttrs from 'markdown-it-attrs'
-import swift from 'highlight.js/lib/languages/swift'
-import { components, highlighter } from 'nhsuk-frontend/lib'
+import { components } from 'nhsuk-frontend/lib'
 import { highlight } from 'nhsuk-frontend/lib/nunjucks/filters/highlight.mjs'
-
-highlighter.registerLanguage('swift', swift)
 
 import matter from 'gray-matter'
 import prettier from 'prettier'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # NHS App Frontend Changelog
 
+## Unreleased
+
+### 🆕 New features
+
+- Updated to [NHS.UK frontend v10.6.1](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v10.6.1) - [pull request #573](https://github.com/nhsuk/nhsapp-frontend/pull/573)
+
+### 🔧 Fixes
+
+- Fix Sass 1.80.0 `import` and `global-builtin` deprecations
+- Fix Sass 1.95.0 `if-function` deprecation
+
 ## `v5.2.0` - 25 August 2026
 
 ### 🆕 New features

--- a/docs/ios/banner.md
+++ b/docs/ios/banner.md
@@ -59,7 +59,7 @@ Use the solid style for less important prompts, such as inviting users to give f
 <img src="/assets/images/ios/banner-solid.png">
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/banner/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/buttons.md
+++ b/docs/ios/buttons.md
@@ -29,7 +29,7 @@ The button scales with Dynamic Type and adapts to Dark Mode. Text wraps onto mul
 Use a standard [SwiftUI Button](https://developer.apple.com/documentation/swiftui/button) and apply NHS styles using the `.buttonStyle()` modifier.
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/buttons/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/campaign-card.md
+++ b/docs/ios/campaign-card.md
@@ -53,7 +53,7 @@ Use the campaign card within a SwiftUI view.
 The card triggers an action when tapped. Specify this using the `action` closure. The action can navigate to another screen, present a sheet, open a link, or trigger any other action.
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/campaign-card/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/card-style.md
+++ b/docs/ios/card-style.md
@@ -24,7 +24,7 @@ Apply the modifier to the outermost view of your card content:
 <img src="/assets/images/ios/card-style.png" width="375">
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/card-style/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/home-menu.md
+++ b/docs/ios/home-menu.md
@@ -33,7 +33,7 @@ The layout varies by screen size and text size:
 Use the home menu within a SwiftUI view:
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/home-menu/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/profile-card.md
+++ b/docs/ios/profile-card.md
@@ -31,7 +31,7 @@ Each card has an icon, the name, a line of supporting text, and a chevron showin
 ## How to use
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 {% include "ios/profile-card/swift-options.md" %}
 {% endcall %}
 

--- a/docs/ios/toolbar.md
+++ b/docs/ios/toolbar.md
@@ -58,7 +58,7 @@ The back button will appear in the toolbar at the top left automatically when us
 The close button should be added to most screens presented as a modal, allowing the user to return to the screen beneath it. Do not use it when the user has reached the end of a journey - use the 'done' button instead.
 
 {% from "details/macro.njk" import details %}
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option              | Description                                                                             |
 | ------------------- | --------------------------------------------------------------------------------------- |
@@ -90,7 +90,7 @@ struct BookAppointmentView: View {
 
 The 'done' button is added to any screens presented as modal, when the user has reached the end of a journey and has completed a task. For example, after booking an appointment.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option   | Description                                    |
 | -------- | ---------------------------------------------- |
@@ -123,7 +123,7 @@ The filter button can be added to list views, enabling a user to bring up option
 
 It is presented with both a filter icon and the word 'Filter', as research shows that not all users understand the icon. When filters are active, the button changes to using blue, bold text, and the number of active filters is shown in brackets.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option              | Description                                    |
 | ------------------- | ---------------------------------------------- |
@@ -153,7 +153,7 @@ struct MessagesView: View {
 
 The flag button can be used on detail views for items which the user can flag, to mark the item.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option        | Description                                          |
 | ------------- | ---------------------------------------------------- |
@@ -187,7 +187,7 @@ struct MessageView: View {
 
 The messages button is used on the home screen only, and serves as both an indicator of any unread messages, and a way to navigate to the messages section.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option        | Description                                    |
 | ------------- | ---------------------------------------------- |
@@ -240,7 +240,7 @@ struct HomeView: View {
 
 Use an icon toolbar button when you are confident through research that most users can understand the icon.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option              | Description                                                                            |
 | ------------------- | -------------------------------------------------------------------------------------- |
@@ -276,7 +276,7 @@ struct MessageView: View {
 
 If you need to add a toolbar button which cannot be reliably identified using an icon, use a text toolbar button instead. This will use the NHS font.
 
-{% call details({ summaryText: "Swift options" }) %}
+{% call details({ summary: "Swift options" }) %}
 
 | Option               | Description                                                                            |
 | -------------------- | -------------------------------------------------------------------------------------- |

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 import gulp from 'gulp'
-import * as dartSass from 'sass'
+import * as dartSass from 'sass-embedded'
 import gulpSass from 'gulp-sass'
 import gulpClean from 'gulp-clean'
 import zip from 'gulp-zip'
@@ -22,7 +22,7 @@ function compileCSS() {
     .src(['src/all.scss'], { sourcemaps: true })
     .pipe(
       sass({
-        includePaths: ['node_modules', 'node_modules/nhsuk-frontend/dist'],
+        loadPaths: ['node_modules', 'node_modules/nhsuk-frontend/dist'],
         // Enable source maps so line numbers map back to source during development
         sourceMap: true,
         sourceMapIncludeSources: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,11 +22,7 @@ function compileCSS() {
     .src(['src/all.scss'], { sourcemaps: true })
     .pipe(
       sass({
-        includePaths: [
-          'node_modules',
-          'node_modules/nhsuk-frontend/dist',
-          'node_modules/nhsuk-frontend/src'
-        ],
+        includePaths: ['node_modules', 'node_modules/nhsuk-frontend/dist'],
         // Enable source maps so line numbers map back to source during development
         sourceMap: true,
         sourceMapIncludeSources: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "highlight.js": "^11.11.1",
         "markdown-it-anchor": "^9.0.1",
         "markdown-it-attrs": "^5.0.0",
-        "nhsuk-frontend": "^10.5.2",
+        "nhsuk-frontend": "^10.6.1",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "plugin-error": "^1.0.1",
@@ -3887,9 +3887,9 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
-      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.6.1.tgz",
+      "integrity": "sha512-PZorqQZjZx/A26yJoskCL9z0ib6AtkAyF0o4K/RHr8zRrJyXrUOCnMbjy0VNXsGO4tfTNMwqlkwATKs4a0xayw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "gulp-connect": "^5.7.0",
         "gulp-nunjucks": "^6.0.0",
         "gulp-rename": "^2.0.0",
-        "gulp-sass": "^5.1.0",
+        "gulp-sass": "^6.0.1",
         "gulp-uglify": "^3.0.2",
         "gulp-zip": "^6.0.0",
         "highlight.js": "^11.11.1",
@@ -31,7 +31,7 @@
         "outdent": "^0.8.0",
         "plugin-error": "^1.0.1",
         "prettier": "^3.2.5",
-        "sass": "^1.74.1"
+        "sass-embedded": "^1.103.1"
       },
       "engines": {
         "node": "^24.11.0",
@@ -550,6 +550,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@gulpjs/messages": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@gulpjs/messages/-/messages-1.1.0.tgz",
@@ -700,6 +707,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -721,6 +731,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -742,6 +755,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -763,6 +779,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -784,6 +803,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,6 +827,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -861,9 +886,9 @@
       }
     },
     "node_modules/@parcel/watcher/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1599,6 +1624,17 @@
       "dev": true,
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+      "integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
       }
     },
     "node_modules/commander": {
@@ -2855,10 +2891,11 @@
       }
     },
     "node_modules/gulp-sass": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
-      "integrity": "sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-6.0.1.tgz",
+      "integrity": "sha512-4wonidxB8lGPHvahelpGavUBJAuERSl+OIVxPCyQthK4lSJhZ/u3/qjFcyAtnMIXDl6fXTn34H4BXsN7gt54kQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "picocolors": "^1.0.0",
@@ -4524,11 +4561,12 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
-      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
+      "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chokidar": "^5.0.0",
         "immutable": "^5.1.5",
@@ -4544,12 +4582,385 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
+    "node_modules/sass-embedded": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.103.1.tgz",
+      "integrity": "sha512-UVIuFZPzz+4DXYbHzQ5gKaKkyP2IH3Sc/WoF63N2V7QIfnC2E9UpQAtiKlCVJTfBe43HRgHDBLnXpZkYAEBsNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.7.0",
+        "immutable": "^5.1.5",
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
+        "varint": "^6.0.0"
+      },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-all-unknown": "1.103.1",
+        "sass-embedded-android-arm": "1.103.1",
+        "sass-embedded-android-arm64": "1.103.1",
+        "sass-embedded-android-riscv64": "1.103.1",
+        "sass-embedded-android-x64": "1.103.1",
+        "sass-embedded-darwin-arm64": "1.103.1",
+        "sass-embedded-darwin-x64": "1.103.1",
+        "sass-embedded-linux-arm": "1.103.1",
+        "sass-embedded-linux-arm64": "1.103.1",
+        "sass-embedded-linux-musl-arm": "1.103.1",
+        "sass-embedded-linux-musl-arm64": "1.103.1",
+        "sass-embedded-linux-musl-riscv64": "1.103.1",
+        "sass-embedded-linux-musl-x64": "1.103.1",
+        "sass-embedded-linux-riscv64": "1.103.1",
+        "sass-embedded-linux-x64": "1.103.1",
+        "sass-embedded-unknown-all": "1.103.1",
+        "sass-embedded-win32-arm64": "1.103.1",
+        "sass-embedded-win32-x64": "1.103.1"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.103.1.tgz",
+      "integrity": "sha512-MwX2ap06TbImAqlbnH6EndgBBejk6Eq2QB6Ae2hukCn9wmXf9cRu27um3mz3tyB4oJOOku0xfHqFH/+ckYj6YA==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sass": "1.103.1"
+      }
+    },
+    "node_modules/sass-embedded-android-arm": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.103.1.tgz",
+      "integrity": "sha512-p36WHpsu5HEo2+NVNbI2Nmb8VgVH0xwOQyzghvZhF7ikGCzEVYI5BP28vHUZlCcgj2TUvMEJKI2lV336a+F/sg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-arm64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.103.1.tgz",
+      "integrity": "sha512-jBXWMksyz55XeLOWvQs64BqiG5DcqflmMxcvMoA2oHtQT/7XZ02hBn502qpcF/q8Qd+qqG/hU5ccM+hGXrbQZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.103.1.tgz",
+      "integrity": "sha512-rzrH7RNntk0rx+zCE9xOiAIUt37D1cQKvFfcoX0xiePdGbNHBN8DWKaWN9vaCRfbgKCmxPjevzaqFNI/G/8E1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-android-x64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.103.1.tgz",
+      "integrity": "sha512-EQglAJXJutuIcqgZf7YOwzao2ND6ow/OgqN+cM48/Qaeb6AimYmZiUJmM9FFcmS3Q2n1k6/2OU3l3Hlin7bFpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.103.1.tgz",
+      "integrity": "sha512-rlaBeCul8pLbDRKdBAxdDxSBwFU5fbX42ci6CxW2Vbs34jWTMQ72+nE2v2KkGGce+JnYbb7UV6xDP/4uDWWi+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.103.1.tgz",
+      "integrity": "sha512-VSKFfhI//AOct6ppFmAaSH7tlW2LOFECMGs77jIoWf0ZjvGch/3sc9lUTTdIaYIOnTS4qpZck+8OcI2D0G92QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.103.1.tgz",
+      "integrity": "sha512-tJRLPUtBwXHTnBnG7I39gQvCLreuOHLLCMyKHPR1hQ7aFNwiZjADYzKMRQPNMUqti/Os9z+6I7V13FqgQHfuzg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": "glibc",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.103.1.tgz",
+      "integrity": "sha512-rC+80/Xr9svo0ka2Zr/sjD+N1zEHTw2Urm/nsEjaVp5HSH2i22jwhTKTIqie2OLl6ti+qdYnbI0sSfxOYRtgrg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": "glibc",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.103.1.tgz",
+      "integrity": "sha512-N8L/kgVzXpnH+8d6ErIzqvb0l8kHODR3OfPaf0Azw6DOLGtEjwDRUbHno+G7iogGzyPOjKsM8OdyqHJj/bpTdw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": "musl",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-arm64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.103.1.tgz",
+      "integrity": "sha512-jMgG/C/VMo7+ShMFdk0xjJmQmYkj1PbJu/yrQiaQHpuo5pE2G+vnkEgsuM5EM3lTQ4MbMfnf715qy1fkbNPiUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": "musl",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.103.1.tgz",
+      "integrity": "sha512-LZm8rEvI6sKU87qPOlODsYeAs7CmWy0B4ShYkjG4OMcGCcV4Ffxn25XW4TFqmruThITQvJ8WT+WGblzdoxYgbA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": "musl",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-musl-x64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.103.1.tgz",
+      "integrity": "sha512-rmKzgk4t6RpaDhSefbbnk5yrA4pk1nHlVhJECGay8yMfzK8eglATeY9fzPgt89xCuQk6rkOiy11e+m8tLYOW5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": "musl",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.103.1.tgz",
+      "integrity": "sha512-xydQmtxla31uMrmN6z+mAogVGdEMDmkUElVq2+udomX/TPZDYJBkApEyJl237M2VLWVv29v1N4U4i2Z4xa7SDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": "glibc",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.103.1.tgz",
+      "integrity": "sha512-Rln1oWm0MWKzzemOgQWrRFzfVBARwS9qxAidZPpCQHSohzPnWizFkmY1CUJad/YJNsA7sscueMdX63OEvxoM8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": "glibc",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.103.1.tgz",
+      "integrity": "sha512-p7kI4US8+n+YguKczXh+4KcodJnk+8cwv+QFdvMaz3OfPrdHV0EnhPsaVDWD9qXb1XXCEdUhpp6vQwGk3eKc3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "dependencies": {
+        "sass": "1.103.1"
+      }
+    },
+    "node_modules/sass-embedded-win32-arm64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.103.1.tgz",
+      "integrity": "sha512-/0renOj3SpZGu4TA8CZJ6qZbTxGZk1khkPfiBTmV1uFB40ESYM5VsdXNj76P07bsAjIj9X2fCjTafLQFLSd9Nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.103.1.tgz",
+      "integrity": "sha512-fIg60j9u5YlLUU3W8FvySMR4HHIo9R12HHFQTW7njyQ8nXqgR+t+XfCzGJloQka8g583BlAfu31Q76Ljr5o+9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/sass/node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -4561,11 +4972,12 @@
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -4959,10 +5371,12 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5121,6 +5535,29 @@
       "dev": true,
       "optionalDependencies": {
         "semver": "^6.3.0"
+      }
+    },
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sync-message-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
+      "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/teex": {
@@ -5425,6 +5862,13 @@
       "engines": {
         "node": ">= 10.13.0"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vinyl": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "highlight.js": "^11.11.1",
     "markdown-it-anchor": "^9.0.1",
     "markdown-it-attrs": "^5.0.0",
-    "nhsuk-frontend": "^10.5.2",
+    "nhsuk-frontend": "^10.6.1",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "plugin-error": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-connect": "^5.7.0",
     "gulp-nunjucks": "^6.0.0",
     "gulp-rename": "^2.0.0",
-    "gulp-sass": "^5.1.0",
+    "gulp-sass": "^6.0.1",
     "gulp-uglify": "^3.0.2",
     "gulp-zip": "^6.0.0",
     "highlight.js": "^11.11.1",
@@ -52,7 +52,7 @@
     "outdent": "^0.8.0",
     "plugin-error": "^1.0.1",
     "prettier": "^3.2.5",
-    "sass": "^1.74.1"
+    "sass-embedded": "^1.103.1"
   },
   "peerDependencies": {
     "nhsuk-frontend": "^10.0.0"

--- a/src/all.scss
+++ b/src/all.scss
@@ -1,17 +1,17 @@
 // Settings
-@import "settings/colours";
+@forward "settings/colours";
 
 // styles
-@import "styles/icon/icons";
+@forward "styles/icon/icons";
 
 // components
-@import "components/badge/badge";
-@import "components/button";
-@import "components/card/card";
-@import "components/tag/tag";
-@import "components/timeline/timeline";
-@import "components/summary-list";
+@forward "components/badge/badge";
+@forward "components/button";
+@forward "components/card/card";
+@forward "components/tag/tag";
+@forward "components/timeline/timeline";
+@forward "components/summary-list";
 
 // utilities
-@import "utilities/display";
-@import "utilities/truncate";
+@forward "utilities/display";
+@forward "utilities/truncate";

--- a/src/components/badge/_badge.scss
+++ b/src/components/badge/_badge.scss
@@ -1,14 +1,11 @@
+@use "sass:math";
+@use "nhsuk-frontend/dist/nhsuk/core/settings" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/helpers" as *;
+
 // ==========================================================================
 // COMPONENTS / #BADGE
 // ==========================================================================
-
-@use "sass:math";
-
-@use "nhsuk-frontend/dist/nhsuk/core/settings/colours-applied" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/typography" as *;
 
 .nhsapp-badge {
   @include nhsuk-font-size(19);

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -1,4 +1,4 @@
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
 
 $button-border-radius: nhsuk-spacing(2);
 

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,9 +1,8 @@
 @use "sass:list";
-@use "nhsuk-frontend/dist/nhsuk/core/settings/colours-applied" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/typography" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/settings" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/helpers" as *;
+@use "../../settings/colours-applied" as *;
 
 /** These variables are not defined in a separate scss file in the nhsuk-frontend,
  * so we can't import them without bringing in the actual classes also.

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -1,3 +1,4 @@
+@use "sass:list";
 @use "nhsuk-frontend/dist/nhsuk/core/settings/colours-applied" as *;
 @use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
 @use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
@@ -350,8 +351,8 @@ $nhsapp-card-variants: (
 
 // Generate classes for each colour variant
 @each $variant, $colors in $nhsapp-card-variants {
-  $background-colour: nth($colors, 1);
-  $text-colour: nth($colors, 2);
+  $background-colour: list.nth($colors, 1);
+  $text-colour: list.nth($colors, 2);
 
   .nhsapp-cards--#{$variant} .nhsapp-card,
   .nhsapp-card--#{$variant} {

--- a/src/components/summary-list/_index.scss
+++ b/src/components/summary-list/_index.scss
@@ -1,6 +1,5 @@
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/settings/colours-applied" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/settings" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
 
 .nhsapp-summary-list {
   // Override the NHS UK Frontend summary list component to display two columns on mobile

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -1,10 +1,10 @@
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/helpers" as *;
+@use "../../settings/colours-applied" as *;
+
 /* ==========================================================================
   #TAG
   ========================================================================== */
-
-@use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/typography" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
 
 $color_tag-aqua-green-background: nhsapp-colour("pale-aqua-green");
 $color_tag-aqua-green-text: nhsapp-colour("dark-aqua-green");

--- a/src/components/timeline/_timeline.scss
+++ b/src/components/timeline/_timeline.scss
@@ -1,7 +1,6 @@
-@use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/typography" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/settings" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/helpers" as *;
 
 $timeline-badge-size-mobile: 16px;
 $timeline-badge-small-size-mobile: 12px;

--- a/src/components/timeline/_timeline.scss
+++ b/src/components/timeline/_timeline.scss
@@ -32,7 +32,7 @@ $timeline-border-width: 2px;
 
   margin-left: dot-ml(dot-size($size));
   margin-top: if($size == "default", $mt, $mt-small);
-  margin-right: if($size == "default", nhsuk-spacing(4), nhsuk-spacing(4) + 2px);
+  margin-right: if($size == "default", nhsuk-spacing(4), nhsuk-spacing(4, $adjustment: 2px));
 
   @include nhsuk-media-query($from: tablet) {
     $tablet: dot-size($size) + 4px;

--- a/src/components/timeline/_timeline.scss
+++ b/src/components/timeline/_timeline.scss
@@ -31,15 +31,27 @@ $timeline-border-width: 2px;
   width: dot-size($size);
 
   margin-left: dot-ml(dot-size($size));
-  margin-top: if($size == "default", $mt, $mt-small);
-  margin-right: if($size == "default", nhsuk-spacing(4), nhsuk-spacing(4, $adjustment: 2px));
+
+  @if $size == "default" {
+    margin-top: $mt;
+    margin-right: nhsuk-spacing(4);
+  } @else {
+    margin-top: $mt-small;
+    margin-right: nhsuk-spacing(4, $adjustment: 2px);
+  }
 
   @include nhsuk-media-query($from: tablet) {
     $tablet: dot-size($size) + 4px;
 
     height: $tablet;
     margin-left: dot-ml($tablet);
-    margin-top: if($size == "default", dot-mt-tablet($mt), dot-mt-tablet($mt-small));
+
+    @if $size == "default" {
+      margin-top: dot-mt-tablet($mt);
+    } @else {
+      margin-top: dot-mt-tablet($mt-small);
+    }
+
     width: $tablet;
   }
 }

--- a/src/styles/icon/_icons.scss
+++ b/src/styles/icon/_icons.scss
@@ -1,7 +1,6 @@
-@use "nhsuk-frontend/dist/nhsuk/core/settings/colours-applied" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/helpers/colour" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
-@use "nhsuk-frontend/dist/nhsuk/core/tools/spacing" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/settings" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/helpers" as *;
 
 .nhsapp-icon {
   fill: $nhsuk-link-colour; // Set default icon colour to NHS blue

--- a/src/utilities/_display.scss
+++ b/src/utilities/_display.scss
@@ -1,4 +1,4 @@
-@use "nhsuk-frontend/dist/nhsuk/core/tools/sass-mq" as *;
+@use "nhsuk-frontend/dist/nhsuk/core/tools" as *;
 
 .nhsapp-u-hide-from-tablet {
   @include nhsuk-media-query($from: tablet) {


### PR DESCRIPTION
Thought I'd open a helpful little PR

* NHS.UK frontend v10.6.1 update
* Rename details component option `summaryText` → `summary`
* Fix Sass deprecations for `if()`, `nth()` and `@import`
* Update to Sass 1.103.1 and use modern compiler