### PR TITLE
Avoid empty card title markup

### DIFF
--- a/src/components/card/card.njk
+++ b/src/components/card/card.njk
@@ -39,7 +39,7 @@
            {%- if params.linkAriaLabel %} aria-label="{{ params.linkAriaLabel }}"{% endif %}>
           {{ params.titleHtml | safe if params.titleHtml else params.title }}
         </a>
-      {%- else -%}
+      {%- elif params.title or params.titleHtml -%}
         {%- if params.headingLevel -%}
           <h{{ params.headingLevel }} class="nhsapp-card__title {{ params.titleClasses if params.titleClasses }}">
             {{ params.titleHtml | safe if params.titleHtml else params.title }}


### PR DESCRIPTION
## Summary

- do not render a card title element when neither `title` nor `titleHtml` is provided
- preserve linked, heading and paragraph titles, including `titleHtml` and empty-`titleHtml` fallback behaviour
- remove the empty `<p class="nhsapp-card__title"></p>` from the redesigned stacked footer card

## Why this is the narrow fix

The [v5.2.0 footer redesign in #551](https://github.com/nhsuk/nhsapp-frontend/pull/551) intentionally represents the visual footer as a second card with `descriptionHtml` and no title. The current unconditional `else` branch still renders title markup for that valid titleless card.

Changing that branch to `elif params.title or params.titleHtml` makes title markup conditional on title content. It does not change the output of documented cards that have a text or HTML title.

## Scope

- one source template changed: `src/components/card/card.njk`
- no CSS or JavaScript change
- no change to the card macro arguments
- no change to the wrapper, description, footer, badge, image or chevron branches

## Verification

Audited commit: [`4c39762e10075dbe156174c7cb8031171c45c65f`](https://github.com/nhsuk/nhsapp-frontend/pull/575/commits/4c39762e10075dbe156174c7cb8031171c45c65f)

PR base: [`775518abf9f7a88e2fdd4a4c28048ca8c3f0b639`](https://github.com/nhsuk/nhsapp-frontend/commit/775518abf9f7a88e2fdd4a4c28048ca8c3f0b639)

Current `main` checked during re-audit: [`5522cd3d72e369ee54c35142c17e0b0e48af1c43`](https://github.com/nhsuk/nhsapp-frontend/commit/5522cd3d72e369ee54c35142c17e0b0e48af1c43). The card template is unchanged between the PR base and that commit, and the PR merges cleanly with it.

Fresh local verification used Node `24.19.0` and npm `11.6.4`, matching the repository's Node 24 and npm engine constraints:

- `npm ci`
- `npm run lint`
- direct Nunjucks assertions for description-only, footer-only and heading-level-without-title cards
- base-versus-candidate rendering comparison: 8 supported title configurations remained byte-for-byte identical; 3 titleless configurations lost only the empty title element
- `npm run docs:build`
- `npm run prepack`
- source-versus-bundled template comparison with `cmp`

All checks passed. The Sass build emitted existing deprecation warnings but no errors.

Public status for the exact commit:

- [Netlify deploy preview](https://deploy-preview-575--nhsapp-frontend.netlify.app) is successful
- the upstream `PR checks` workflow is currently `action_required`, so it is not being represented here as a passing CI run

Closes #574
