### PR TITLE
Add Sass index entrypoint

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,3 +12,21 @@ jobs:
           node-version-file: .nvmrc
       - run: npm ci
       - run: npm run lint
+
+  sass-entrypoints:
+    name: Sass entrypoints (${{ matrix.sass-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sass-version: [locked, '1.74.1']
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+      - run: npm ci
+      - name: Install minimum supported Dart Sass
+        if: matrix.sass-version != 'locked'
+        run: npm install --no-save --package-lock=false --ignore-scripts "sass@${{ matrix.sass-version }}"
+      - run: npm run test:sass-entrypoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS App Frontend Changelog
 
+## Unreleased
+
+### 🆕 New features
+
+- Added package-level Sass entrypoints for importing all NHS App frontend styles or individual components using Sass `@use` syntax - [pull request #576](https://github.com/nhsuk/nhsapp-frontend/pull/576)
+
 ## `v5.2.0` - 25 August 2026
 
 ### 🆕 New features

--- a/docs/get-started/installing-with-npm.md
+++ b/docs/get-started/installing-with-npm.md
@@ -31,16 +31,18 @@ After you have installed NHS App frontend the `nhsapp-frontend` package will app
 
 You need to import the NHS App frontend styles into the main Sass file in your project. You should place the below code before your own Sass rules (or Sass imports) if you want to override NHS App frontend with your own styles.
 
+Configure Sass to resolve dependencies from `node_modules`, rather than adding the project working directory to `loadPaths`. For example, use `--load-path=node_modules` with the Sass CLI.
+
 1. To import all components, add the below to your Sass file:
 
-```CSS
-@import "node_modules/nhsapp-frontend/dist/nhsapp/all";
+```scss
+@import "nhsapp-frontend/dist/nhsapp";
 ```
 
 2. To import an individual component (for example a button), add the below to your Sass file:
 
-```CSS
-@import "node_modules/nhsapp-frontend/dist/nhsapp/components/button/button";
+```scss
+@import "nhsapp-frontend/dist/nhsapp/components/button";
 ```
 
 ## Importing assets

--- a/docs/get-started/installing-with-npm.md
+++ b/docs/get-started/installing-with-npm.md
@@ -36,13 +36,13 @@ Configure Sass to resolve dependencies from `node_modules`, rather than adding t
 1. To import all components, add the below to your Sass file:
 
 ```scss
-@import "nhsapp-frontend/dist/nhsapp";
+@use "nhsapp-frontend/dist/nhsapp";
 ```
 
 2. To import an individual component (for example a button), add the below to your Sass file:
 
 ```scss
-@import "nhsapp-frontend/dist/nhsapp/components/button";
+@use "nhsapp-frontend/dist/nhsapp/components/button";
 ```
 
 ## Importing assets

--- a/docs/get-started/installing-with-npm.md
+++ b/docs/get-started/installing-with-npm.md
@@ -11,6 +11,8 @@ To use NHS App frontend with node package manager (npm) you must:
 
 2. Create a [package.json file](https://docs.npmjs.com/files/package.json) if you don’t already have one. You can create a default `package.json` file by running `npm init` from the root of your application.
 
+3. Use Dart Sass 1.74.1 or later to compile styles. The documented `@use` entrypoints are not supported by Node Sass or LibSass.
+
 ## Installation
 
 To install, run:
@@ -43,6 +45,13 @@ Configure Sass to resolve dependencies from `node_modules`, rather than adding t
 
 ```scss
 @use "nhsapp-frontend/dist/nhsapp/components/button";
+```
+
+Existing projects can keep the legacy Dart Sass import while migrating. New projects should use `@use`.
+
+```scss
+// Legacy Dart Sass import, retained for compatibility
+@import "nhsapp-frontend/dist/nhsapp/all";
 ```
 
 ## Importing assets

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,7 +73,16 @@ function copyAssets() {
  * Copy nunjucks and source scss files into a namespaced directory
  */
 function copySource() {
-  return gulp.src('src/**/*').pipe(gulp.dest('dist/nhsapp'))
+  return gulp
+    .src(['src/**/*', '!src/_nhsapp.scss'])
+    .pipe(gulp.dest('dist/nhsapp'))
+}
+
+/**
+ * Copy the Sass resolver shim alongside the compiled CSS
+ */
+function copySassEntrypoint() {
+  return gulp.src('src/_nhsapp.scss').pipe(gulp.dest('dist'))
 }
 
 /* Recompile CSS when there are any changes */
@@ -101,7 +110,8 @@ const bundle = gulp.series([
   compileCSS,
   minifyCSS,
   copyAssets,
-  copySource
+  copySource,
+  copySassEntrypoint
 ])
 
 const release = gulp.series([
@@ -109,6 +119,7 @@ const release = gulp.series([
   compileCSS,
   minifyCSS,
   copySource,
+  copySassEntrypoint,
   createZip
 ])
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "docs:build": "npm run css:build && npx @11ty/eleventy",
     "css:watch": "gulp",
     "css:build": "gulp compileCSS",
+    "test:sass-entrypoints": "node scripts/test-sass-entrypoints.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/scripts/test-sass-entrypoints.mjs
+++ b/scripts/test-sass-entrypoints.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const projectRoot = process.cwd()
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const sass = resolve(
+  projectRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'sass.cmd' : 'sass'
+)
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'nhsapp-sass-entrypoints-'))
+
+function run(command, args, cwd = projectRoot) {
+  execFileSync(command, args, { cwd, stdio: 'inherit' })
+}
+
+function compile(input, output, loadPaths) {
+  run(sass, [
+    '--style=compressed',
+    '--no-source-map',
+    ...loadPaths.map((loadPath) => `--load-path=${loadPath}`),
+    input,
+    output
+  ])
+}
+
+function assertContains(file, value) {
+  assert.ok(
+    readFileSync(file, 'utf8').includes(value),
+    `${file} must contain ${value}`
+  )
+}
+
+try {
+  run(npm, ['run', 'prepack'])
+
+  assert.ok(existsSync(join(projectRoot, 'dist', '_nhsapp.scss')))
+  assert.ok(existsSync(join(projectRoot, 'dist', 'nhsapp', 'index.scss')))
+  assert.ok(!existsSync(join(projectRoot, 'dist', 'nhsapp', '_nhsapp.scss')))
+
+  const packDirectory = join(temporaryRoot, 'pack')
+  mkdirSync(packDirectory)
+  run(npm, ['pack', '--ignore-scripts', '--pack-destination', packDirectory])
+
+  const packageArchives = readdirSync(packDirectory).filter((file) =>
+    file.endsWith('.tgz')
+  )
+  assert.equal(packageArchives.length, 1)
+
+  const consumerDirectory = join(temporaryRoot, 'consumer')
+  mkdirSync(consumerDirectory)
+  writeFileSync(
+    join(consumerDirectory, 'package.json'),
+    `${JSON.stringify({ private: true }, null, 2)}\n`
+  )
+
+  run(
+    npm,
+    [
+      'install',
+      '--ignore-scripts',
+      '--legacy-peer-deps',
+      '--no-audit',
+      '--no-fund',
+      '--no-package-lock',
+      '--no-save',
+      join(packDirectory, packageArchives[0])
+    ],
+    consumerDirectory
+  )
+
+  const consumerModules = join(consumerDirectory, 'node_modules')
+  symlinkSync(
+    join(projectRoot, 'node_modules', 'nhsuk-frontend'),
+    join(consumerModules, 'nhsuk-frontend'),
+    process.platform === 'win32' ? 'junction' : 'dir'
+  )
+
+  const installedPackage = join(consumerModules, 'nhsapp-frontend')
+  assert.ok(existsSync(join(installedPackage, 'dist', '_nhsapp.scss')))
+  assert.ok(existsSync(join(installedPackage, 'dist', 'nhsapp', 'index.scss')))
+  assert.ok(
+    !existsSync(join(installedPackage, 'dist', 'nhsapp', '_nhsapp.scss'))
+  )
+
+  const fixtures = {
+    'root-use': '@use "nhsapp-frontend/dist/nhsapp";\n',
+    'root-import': '@import "nhsapp-frontend/dist/nhsapp";\n',
+    'issue-566-import': '@import "node_modules/nhsapp-frontend/dist/nhsapp";\n',
+    'legacy-import': '@import "nhsapp-frontend/dist/nhsapp/all";\n',
+    'button-use': '@use "nhsapp-frontend/dist/nhsapp/components/button";\n'
+  }
+
+  for (const [name, source] of Object.entries(fixtures)) {
+    const input = join(consumerDirectory, `${name}.scss`)
+    writeFileSync(input, source)
+    compile(input, join(consumerDirectory, `${name}.css`), [consumerModules])
+  }
+
+  const rootCss = readFileSync(join(consumerDirectory, 'root-use.css'), 'utf8')
+  for (const equivalent of [
+    'root-import',
+    'issue-566-import',
+    'legacy-import'
+  ]) {
+    assert.equal(
+      readFileSync(join(consumerDirectory, `${equivalent}.css`), 'utf8'),
+      rootCss
+    )
+  }
+  assertContains(join(consumerDirectory, 'root-use.css'), '.nhsapp-card')
+  assertContains(join(consumerDirectory, 'root-use.css'), '.nhsapp-button')
+  assertContains(join(consumerDirectory, 'button-use.css'), '.nhsapp-button')
+
+  run(npm, ['run', 'release'])
+
+  const packageJson = JSON.parse(
+    readFileSync(join(projectRoot, 'package.json'), 'utf8')
+  )
+  const releaseArchive = join(
+    projectRoot,
+    'dist',
+    `nhsapp-frontend-${packageJson.version}.zip`
+  )
+  assert.ok(existsSync(releaseArchive))
+
+  const releaseDirectory = join(temporaryRoot, 'release')
+  mkdirSync(releaseDirectory)
+  run('unzip', ['-q', releaseArchive, '-d', releaseDirectory])
+
+  const releaseFiles = readdirSync(releaseDirectory, { recursive: true })
+  assert.ok(releaseFiles.includes('index.scss'))
+  assert.ok(releaseFiles.includes('all.scss'))
+  assert.ok(!releaseFiles.some((file) => file.endsWith('_nhsapp.scss')))
+
+  const releaseFixture = join(temporaryRoot, 'release.scss')
+  const releaseCss = join(temporaryRoot, 'release.css')
+  writeFileSync(releaseFixture, '@use "index";\n')
+  compile(releaseFixture, releaseCss, [
+    releaseDirectory,
+    join(projectRoot, 'node_modules')
+  ])
+  assertContains(releaseCss, '.nhsapp-card')
+  assertContains(releaseCss, '.nhsapp-button')
+
+  console.log('Sass package entrypoint contract verified.')
+} finally {
+  rmSync(temporaryRoot, { force: true, recursive: true })
+}

--- a/src/_nhsapp.scss
+++ b/src/_nhsapp.scss
@@ -1,0 +1,1 @@
+@import "nhsapp/index";

--- a/src/_nhsapp.scss
+++ b/src/_nhsapp.scss
@@ -1,1 +1,1 @@
-@import "nhsapp/index";
+@forward "nhsapp/index";

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,0 +1,1 @@
+@import "all";

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,1 +1,1 @@
-@import "all";
+@forward "all";


### PR DESCRIPTION
## Summary

- add package-level Sass entrypoints so `nhsapp-frontend/dist/nhsapp` resolves to Sass source rather than the compiled CSS file
- use `@forward` in the entrypoints and document `@use` for modern Sass consumers
- preserve the CSS output and the existing `/all` import
- document the existing button-component shortcut without adding a duplicate component shim

## Why this needs two entrypoints

The npm package currently contains both:

- `dist/nhsapp.css`
- the `dist/nhsapp/` Sass source directory

Adding only `dist/nhsapp/index.scss` does not make the extensionless `nhsapp-frontend/dist/nhsapp` import select Sass source because the compiled CSS file shares that path.

The package therefore needs:

- `dist/_nhsapp.scss`, copied from `src/_nhsapp.scss`, to resolve the extensionless npm import and forward to the namespaced source directory
- `dist/nhsapp/index.scss`, copied from `src/index.scss`, to forward to the existing `all.scss`

The resolver shim is excluded from `dist/nhsapp/` so the package does not publish an unnecessary second copy.

Both entrypoints use `@forward`. This avoids introducing new `@import` deprecations and is compatible with the Sass modernisation in #573. Legacy consumers can continue importing `nhsapp-frontend/dist/nhsapp/all`.

## Documented imports

Configure Sass with `node_modules` as a load path, then use:

```scss
@use "nhsapp-frontend/dist/nhsapp";
```

For the button component only:

```scss
@use "nhsapp-frontend/dist/nhsapp/components/button";
```

## Validation

- `npm ci`
- `npm run lint`
- `npm run docs:build`
- `npm run prepack`
- `npm run release`
- inspected the packed npm artifact
- compiled the root and button entrypoints from a clean consumer
- verified Sass 1.74.1 and the repository compiler
- proved the root shorthand produces byte-identical compressed CSS to the existing `/all` import
- verified legacy `@import` compatibility
- verified the npm package contains `dist/_nhsapp.scss` and `dist/nhsapp/index.scss`
- verified the standalone release ZIP contains its flattened `index.scss` and intentionally excludes the npm-only resolver shim
- applied the candidate on top of #573 and confirmed the documented `@use` imports compile without deprecation warnings

[Persistent package and #573 compatibility workflow](https://github.com/AyobamiH/nhsapp-frontend/actions/runs/33173094173)

Closes #566
