### PR TITLE
Experimental: update design system website to use 2-tier top nav

### DIFF
--- a/docs/_includes/layouts/android.njk
+++ b/docs/_includes/layouts/android.njk
@@ -1,0 +1,23 @@
+---
+section: android
+---
+
+{% extends "./sidebar.njk" %}
+{% from 'nhsapp/components/tag/macro.njk' import nhsappTag %}
+
+{% block content %}
+  {{ nhsappTag({
+  text: 'Work in progress',
+  classes: 'nhsapp-tag--blue nhsuk-u-margin-bottom-4'
+  })}}
+
+  {% if tags and "android" in tags %}
+    <span class="nhsuk-caption-xl">Android</span>
+  {% endif %}
+  <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
+    {{ title }}
+  </h1>
+  <p>{{ description }}</p>
+  {{ content | safe }}
+
+{% endblock %}

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -57,7 +57,7 @@
     }
   }) }}
 
-  {% if page and page.url and '/ios/' in page.url %}
+  {% if section == "ios" %}
     {% set sectionNavItems = [
       {
         href: '/ios/',
@@ -80,7 +80,7 @@
         current: page.url == '/ios/layouts/' or (tags and 'iosLayouts' in tags)
       }
     ] %}
-  {% else %}
+  {% elif section == "web" %}
     {% set sectionNavItems = [
       {
         href: '/get-started/',
@@ -103,9 +103,11 @@
         current: page and page.url and '/patterns/' in page.url
       }
     ] %}
+  {% else %}
+    {% set sectionNavItems = [] %}
   {% endif %}
 
-  {% if page and page.url != '/' %}
+  {% if sectionNavItems and sectionNavItems.length %}
     <div class="nhsuk-width-container">
       {{ sectionNavigation({
         ariaLabel: 'Section navigation',

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -1,6 +1,7 @@
 {% extends "nhsuk/template-with-imports.njk" %}
 
 {% from "icon/macro.njk" import nhsappIcon %}
+{% from "nhsuk/components/section-navigation/macro.njk" import sectionNavigation %}
 
 {% block pageTitle -%}
   {% if title %}{{ title }} - {% endif %}NHS App design system
@@ -28,24 +29,24 @@
     navigation: {
       items: [
         {
-          href: '/get-started/',
-          text: 'Get started',
-          active: page and page.url and '/get-started/' in page.url
+          href: '/',
+          text: 'Home',
+          active: page and page.url == '/'
         },
         {
-          href: '/styles/',
-          text: 'Styles',
-          active: page and page.url and '/styles/' in page.url
+          href: '/web/',
+          text: 'Web',
+          active: page and page.url and page.url != '/' and not ('/ios/' in page.url) and not ('/android/' in page.url) and not ('/community/' in page.url)
         },
         {
-          href: '/components/',
-          text: 'Components',
-          active: page and page.url and '/components/' in page.url
+          href: '/ios/',
+          text: 'iOS',
+          active: page and page.url and '/ios/' in page.url
         },
         {
-          href: '/patterns/',
-          text: 'Patterns',
-          active: page and page.url and '/patterns/' in page.url
+          href: '/android/',
+          text: 'Android',
+          active: page and page.url and '/android/' in page.url
         },
         {
           href: '/community/',
@@ -55,6 +56,64 @@
       ]
     }
   }) }}
+
+  {% if page and page.url and '/ios/' in page.url %}
+    {% set sectionNavItems = [
+      {
+        href: '/ios/',
+        text: 'Get started',
+        current: (page.url == '/ios/') or (tags and 'ios' in tags)
+      },
+      {
+        href: '/ios/styles/',
+        text: 'Styles',
+        current: page.url == '/ios/styles/' or (tags and 'iosStyles' in tags)
+      },
+      {
+        href: '/ios/components/',
+        text: 'Components',
+        current: page.url == '/ios/components/' or (tags and 'iosComponents' in tags)
+      },
+      {
+        href: '/ios/layouts/',
+        text: 'Layouts',
+        current: page.url == '/ios/layouts/' or (tags and 'iosLayouts' in tags)
+      }
+    ] %}
+  {% else %}
+    {% set sectionNavItems = [
+      {
+        href: '/get-started/',
+        text: 'Get started',
+        current: page and page.url and (page.url == '/web/' or '/get-started/' in page.url)
+      },
+      {
+        href: '/styles/',
+        text: 'Styles',
+        current: page and page.url and '/styles/' in page.url
+      },
+      {
+        href: '/components/',
+        text: 'Components',
+        current: page and page.url and '/components/' in page.url
+      },
+      {
+        href: '/patterns/',
+        text: 'Patterns',
+        current: page and page.url and '/patterns/' in page.url
+      }
+    ] %}
+  {% endif %}
+
+  {% if page and page.url != '/' %}
+    <div class="nhsuk-width-container">
+      {{ sectionNavigation({
+        ariaLabel: 'Section navigation',
+        direction: 'horizontal',
+        items: sectionNavItems
+      }) }}
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/docs/_includes/layouts/community.njk
+++ b/docs/_includes/layouts/community.njk
@@ -1,26 +1,10 @@
+---
+section: community
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
-
-{% block beforeContent %}
-  {% if title === "Community" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/community",
-      text: "Community"
-    }) }}
-  {% endif %}
-{% endblock %}
 
 {% set sidebar %}
   {{ appSideNavigation({

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -1,26 +1,10 @@
+---
+section: web
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
-
-{% block beforeContent %}
-  {% if title === "Components" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/components",
-      text: "Components"
-    }) }}
-  {% endif %}
-{% endblock %}
 
 {% set sidebar %}
   {{ appSideNavigation({
@@ -28,9 +12,6 @@
     currentPath: page.url,
     sections: [
       {
-        heading: {
-          text: 'Components'
-        },
         items: collections.component | sort(attribute="data.title")
       },
       {

--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -1,26 +1,10 @@
+---
+section: web
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
-
-{% block beforeContent %}
-  {% if title === "Get started" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/get-started",
-      text: "Get started"
-    }) }}
-  {% endif %}
-{% endblock %}
 
 {% set sidebar %}
   {{ appSideNavigation({

--- a/docs/_includes/layouts/ios.njk
+++ b/docs/_includes/layouts/ios.njk
@@ -1,55 +1,33 @@
+---
+section: ios
+---
+
 {% extends "./sidebar.njk" %}
 {% from 'nhsapp/components/tag/macro.njk' import nhsappTag %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
 
-{% block beforeContent %}
-  {% if title === "iOS" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/ios",
-      text: "iOS"
-    }) }}
-  {% endif %}
-{% endblock %}
+{% if page.url == '/ios/' or (tags and 'ios' in tags) %}
+  {% set sidebarHeading = 'Get started' %}
+  {% set sidebarItems = collections.ios %}
+{% elif page.url == '/ios/styles/' or (tags and 'iosStyles' in tags) %}
+  {% set sidebarHeading = 'Styles' %}
+  {% set sidebarItems = collections.iosStyles %}
+{% elif page.url == '/ios/components/' or (tags and 'iosComponents' in tags) %}
+  {% set sidebarHeading = 'Components' %}
+  {% set sidebarItems = collections.iosComponents %}
+{% elif page.url == '/ios/layouts/' or (tags and 'iosLayouts' in tags) %}
+  {% set sidebarHeading = 'Layouts' %}
+  {% set sidebarItems = collections.iosLayouts %}
+{% endif %}
 
 {% set sidebar %}
   {{ appSideNavigation({
+    label: sidebarHeading,
     currentPath: page.url,
     sections: [
-      {
-        heading: {
-          text: 'Get started'
-        },
-        items: collections.ios | sort(attribute="data.title")
-      },
-      {
-        heading: {
-          text: 'Styles'
-        },
-        items: collections.iosStyles | sort(attribute="data.title")
-      },
-      {
-        heading: {
-          text: 'Components'
-        },
-        items: collections.iosComponents | sort(attribute="data.title")
-      },
-      {
-        heading: {
-          text: 'Layouts'
-        },
-        items: collections.iosLayouts | sort(attribute="data.title")
+      {        
+        items: sidebarItems | sort(attribute="data.title")
       }
     ]
   }) }}
@@ -61,7 +39,7 @@
     classes: 'nhsapp-tag--blue nhsuk-u-margin-bottom-4'
     })}}
 
-  {% if tags and "ios" in tags %}
+  {% if section == "ios" %}
     <span class="nhsuk-caption-xl">iOS</span>
   {% endif %}
   <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-5">
@@ -69,7 +47,7 @@
   </h1>
   <p>{{ description }}</p>
   {{ content | safe }}
-  {% if tags and "ios" in tags %}
+  {% if section == "ios" %}
     {% include "layouts/partials/feedback-section.njk" %}
   {% endif %}
 {% endblock %}

--- a/docs/_includes/layouts/nhsapp-prototype.njk
+++ b/docs/_includes/layouts/nhsapp-prototype.njk
@@ -1,3 +1,7 @@
+---
+section: web
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}

--- a/docs/_includes/layouts/partials/side-navigation.njk
+++ b/docs/_includes/layouts/partials/side-navigation.njk
@@ -3,9 +3,11 @@
     <h2 class="nhsuk-u-visually-hidden">Pages in this section</h2>
     {%- if params.sections %}
       {%- for section in params.sections %}
-        <h{{ section.heading.headingLevel | default(3) }} class="app-side-navigation__title {{- ' ' + section.heading.classes if section.heading.classes }}"{% for attribute, value in section.heading.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+        {% if section.heading %}
+          <h{{ section.heading.headingLevel | default(3) }} class="app-side-navigation__title {{- ' ' + section.heading.classes if section.heading.classes }}"{% for attribute, value in section.heading.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
           {{- section.heading.html | safe if section.heading.html else section.heading.text -}}
         </h{{ section.heading.headingLevel | default(3) }}>
+        {% endif %}
         <ul class="app-side-navigation__list">
           {%- for item in section.items %}
             {% include "./side-navigation-item.njk" %}

--- a/docs/_includes/layouts/pattern.njk
+++ b/docs/_includes/layouts/pattern.njk
@@ -1,26 +1,10 @@
+---
+section: web
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
-
-{% block beforeContent %}
-  {% if title === "Patterns" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/patterns",
-      text: "Patterns"
-    }) }}
-  {% endif %}
-{% endblock %}
 
 {% set sidebar %}
   {{ appSideNavigation({

--- a/docs/_includes/layouts/style.njk
+++ b/docs/_includes/layouts/style.njk
@@ -1,26 +1,10 @@
+---
+section: web
+---
+
 {% extends "./sidebar.njk" %}
 
 {%- from "./partials/side-navigation.njk" import appSideNavigation %}
-
-{% block beforeContent %}
-  {% if title === "Styles" %}
-    {{ breadcrumb({
-      href: "/",
-      text: "Home"
-    }) }}
-  {% else %}
-    {{ breadcrumb({
-      items: [
-        {
-          href: "/",
-          text: "Home"
-        }
-      ],
-      href: "/styles",
-      text: "Styles"
-    }) }}
-  {% endif %}
-{% endblock %}
 
 {% set sidebar %}
   {{ appSideNavigation({
@@ -28,9 +12,6 @@
     currentPath: page.url,
     sections: [
       {
-        heading: {
-          text: 'Styles'
-        },
         items: collections.style | sort(attribute="data.title")
       }
     ]

--- a/docs/android/index.md
+++ b/docs/android/index.md
@@ -1,16 +1,9 @@
 ---
-layout: layouts/base.njk
+layout: layouts/android.njk
 title: Android
 ---
 
 {% from 'nhsapp/components/tag/macro.njk' import nhsappTag %}
-
-{{ nhsappTag({
-  text: 'Work in progress',
-  classes: 'nhsapp-tag--blue nhsuk-u-margin-bottom-4'
-})}}
-
-# Android
 
 We are transforming the NHS App to be more platform-native.
 

--- a/docs/assets/css/components/_hero.scss
+++ b/docs/assets/css/components/_hero.scss
@@ -7,7 +7,7 @@
 .app-hero {
   background-color: nhsuk-colour("blue");
 
-  .nhsuk-hero__wrapper {
+  .nhsuk-hero__content {
     @include nhsuk-media-query($until: tablet) {
       padding-bottom: nhsuk-spacing(5);
       padding-top: nhsuk-spacing(5);

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -2,27 +2,31 @@
 
 {% from 'nhsapp/components/card/macro.njk' import nhsappCardGroup %}
 {% from 'nhsapp/components/card/macro.njk' import nhsappCard %}
+{% from 'nhsuk/components/hero/macro.njk' import hero as nhsukHero %}
 
 {% block header %}
   {{ super() }}
 
-  <section class="nhsuk-hero app-hero">
-    <div class="nhsuk-width-container nhsuk-hero--border">
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-one-half">
-          <div class="nhsuk-hero__wrapper">
-            <h1 class="nhsuk-u-margin-bottom-3">Design and build accessible services for the NHS App</h1>
-            <p class="nhsuk-u-margin-bottom-3">Use the NHS App design system alongside the <a href="https://service-manual.nhs.uk/">NHS digital service manual</a>.</p>
-            <p>The NHS App design system enables teams to avoid repetition by learning from the work and experiences of others.</p>
-            <a href="/get-started/" class="nhsuk-button nhsuk-button--reverse nhsuk-u-margin-bottom-0">Get started</a>
-          </div>
-        </div>
-        <div class="nhsuk-grid-column-one-half">
-          <img class="app-hero-img" src="assets/images/hero-image.svg" alt="" role="presentation">
-        </div>
-      </div>
-    </div>
-  </section>
+  {{ nhsukHero({
+    classes: "app-hero",
+    content: [
+      {
+        heading: "Design and build accessible services for the NHS App",
+        width: "one-half",
+        html: '<p class="nhsuk-u-margin-bottom-3">Use the NHS App design system alongside the <a href="https://service-manual.nhs.uk/">NHS digital service manual</a>.</p><p>The NHS App design system enables teams to avoid repetition by learning from the work and experiences of others.</p><a href="/get-started/" class="nhsuk-button nhsuk-button--reverse nhsuk-u-margin-bottom-0">Get started</a>'
+      },
+      {
+        image: {
+          src: "assets/images/hero-image.svg",
+          alt: "",
+          background: false,
+          border: false,
+          classes: "app-hero-img"
+        },
+        width: "one-half"
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block main %}

--- a/docs/index.njk
+++ b/docs/index.njk
@@ -56,15 +56,20 @@
           <div class="nhsuk-grid-column-full">
             <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible app-section-break nhsuk-u-margin-top-0 app-section-break--width-4">
           </div>
-          <div class="nhsuk-grid-column-one-half app-section__column">
-            <h2>Components</h2>
-            <p>Save time with reusable, accessible components.</p>
-            <p><a href="/components/" class="nhsuk-link--no-visited-state">Browse components</a></p>
+          <div class="nhsuk-grid-column-one-third app-section__column">
+            <h2>Web</h2>
+            <p>Components, patterns and styles for web-based NHS App screens.</p>
+            <p><a href="/web/" class="nhsuk-link--no-visited-state">Browse web design system</a></p>
           </div>
-          <div class="nhsuk-grid-column-one-half app-section__column">
-            <h2>Patterns</h2>
-            <p>Tested and agreed solutions to common needs.</p>
-            <p><a href="/patterns/" class="nhsuk-link--no-visited-state">Browse patterns</a></p>
+          <div class="nhsuk-grid-column-one-third app-section__column">
+            <h2>iOS</h2>
+            <p>Styles, components and layouts for native iOS screens.</p>
+            <p><a href="/ios/" class="nhsuk-link--no-visited-state">Browse iOS design system</a></p>
+          </div>
+          <div class="nhsuk-grid-column-one-third app-section__column">
+            <h2>Android</h2>
+            <p>Styles, components and layouts for native Android screens.</p>
+            <p><a href="/android/" class="nhsuk-link--no-visited-state">Browse Android design system</a></p>
           </div>
           <div class="nhsuk-grid-column-full">
             <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible app-section-break nhsuk-u-margin-top-0 app-section-break--width-4">

--- a/docs/ios/components/index.md
+++ b/docs/ios/components/index.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/ios.njk
+isIndex: true
+title: Components
+description: Reusable pieces of interface for native iOS screens in the NHS App.
+---
+
+Use these components when building native iOS screens for the NHS App.

--- a/docs/ios/layouts/index.md
+++ b/docs/ios/layouts/index.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/ios.njk
+isIndex: true
+title: Layouts
+description: Ways of arranging content on native iOS screens in the NHS App.
+---
+
+Use these layouts when building native iOS screens for the NHS App.

--- a/docs/ios/styles/index.md
+++ b/docs/ios/styles/index.md
@@ -1,0 +1,8 @@
+---
+layout: layouts/ios.njk
+isIndex: true
+title: Styles
+description: Make iOS services look and feel like the NHS App.
+---
+
+Use these styles when building native iOS screens for the NHS App.

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -1,5 +1,6 @@
 ---
 layout: layouts/base.njk
+section: web
 title: Web
 description: Design and build web-based screens for the NHS App, such as the online account and journeys accessed through it.
 ---

--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -1,0 +1,16 @@
+---
+layout: layouts/base.njk
+title: Web
+description: Design and build web-based screens for the NHS App, such as the online account and journeys accessed through it.
+---
+
+# Web
+
+Use these components, patterns and styles to design and build web-based screens for the NHS App, such as the [online account](/get-started/) and services accessed through it.
+
+## Sections
+
+- [Get started](/get-started/)
+- [Styles](/styles/)
+- [Components](/components/)
+- [Patterns](/patterns/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "highlight.js": "^11.11.1",
         "markdown-it-anchor": "^9.0.1",
         "markdown-it-attrs": "^5.0.0",
-        "nhsuk-frontend": "^10.5.2",
+        "nhsuk-frontend": "github:nhsuk/nhsuk-frontend#87ca95d59",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "plugin-error": "^1.0.1",
@@ -3889,9 +3889,8 @@
       }
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
-      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
+      "version": "11.0.0-internal.0-preview-add-secondary-navigation",
+      "resolved": "git+ssh://git@github.com/nhsuk/nhsuk-frontend.git#87ca95d59919f0f53495cc6672e2be836fdef5a4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3902,7 +3901,7 @@
         "highlight.js": "^11.0.0",
         "nunjucks": "^3.0.0",
         "outdent": "^0.8.0",
-        "slug": "^9.0.0 || ^11.0.0"
+        "slug": "^9.0.0 || ^11.0.0 || ^12.0.0"
       },
       "peerDependenciesMeta": {
         "@prettier/sync": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "highlight.js": "^11.11.1",
     "markdown-it-anchor": "^9.0.1",
     "markdown-it-attrs": "^5.0.0",
-    "nhsuk-frontend": "^10.5.2",
+    "nhsuk-frontend": "github:nhsuk/nhsuk-frontend#87ca95d59",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "plugin-error": "^1.0.1",


### PR DESCRIPTION
This tries out an IA for combining the web, iOS and Android guidance into a single website, using a second-level horizontal navigation.

This would mean that Web has its own sub-nav:

<img width="1001" height="202" alt="Screenshot 2026-09-09 at 16 35 00" src="https://github.com/user-attachments/assets/97fa6d9d-b32b-4021-b574-b1f497c2d55f" />

And iOS and Android have their own sub-nav:

<img width="1001" height="209" alt="Screenshot 2026-09-09 at 16 34 41" src="https://github.com/user-attachments/assets/cd5fb055-8a8b-4bc7-94e1-0a8d5cd306f6" />


...however the 'Community' section and the home page sit across all 3 platforms.


We could also later decide to move 'Patterns' from being a web-specific sub-section to being a top-level section that sits across all platforms, if it proves to be useful to describe patterns in a more abstract way, with content on the pages describing any differences per-platform.


See https://github.com/NHSDigital/native-nhsapp-ucd-team/issues/91

